### PR TITLE
Add default permissions for page content in a microsites type group. #17

### DIFF
--- a/config/install/group.role.microsite-admin.yml
+++ b/config/install/group.role.microsite-admin.yml
@@ -1,8 +1,11 @@
+uuid: 623c93ec-f373-47e7-bcc4-cdce42654efe
 langcode: en
 status: true
 dependencies:
   config:
     - group.type.microsite
+_core:
+  default_config_hash: MjtMfpf7GO35H_lO7yFJVmSc-osYIT0ydHFlvWdVXsI
 id: microsite-admin
 label: Admin
 weight: 100
@@ -15,15 +18,27 @@ permissions:
   - 'access group_node overview'
   - 'administer group'
   - 'administer members'
+  - 'create group_node:localgov_page entity'
+  - 'delete any group_node:localgov_page content'
+  - 'delete any group_node:localgov_page entity'
   - 'delete group'
   - 'delete group revisions'
+  - 'delete own group_node:localgov_page content'
+  - 'delete own group_node:localgov_page entity'
   - 'edit group'
   - 'leave group'
   - 'revert group revisions'
+  - 'update any group_node:localgov_page content'
+  - 'update any group_node:localgov_page entity'
   - 'update own group_membership content'
+  - 'update own group_node:localgov_page content'
+  - 'update own group_node:localgov_page entity'
   - 'view any unpublished group'
   - 'view group'
   - 'view group revisions'
   - 'view group_membership content'
+  - 'view group_node:localgov_page content'
+  - 'view group_node:localgov_page entity'
   - 'view latest group version'
   - 'view own unpublished group'
+  - 'view unpublished group_node:localgov_page entity'

--- a/config/install/group.role.microsite-admin.yml
+++ b/config/install/group.role.microsite-admin.yml
@@ -1,11 +1,8 @@
-uuid: 623c93ec-f373-47e7-bcc4-cdce42654efe
 langcode: en
 status: true
 dependencies:
   config:
     - group.type.microsite
-_core:
-  default_config_hash: MjtMfpf7GO35H_lO7yFJVmSc-osYIT0ydHFlvWdVXsI
 id: microsite-admin
 label: Admin
 weight: 100

--- a/config/install/group.role.microsite-anonymous.yml
+++ b/config/install/group.role.microsite-anonymous.yml
@@ -1,8 +1,11 @@
+uuid: 823d5541-f8ce-4eda-9958-06c87a885a49
 langcode: en
 status: true
 dependencies:
   config:
     - group.type.microsite
+_core:
+  default_config_hash: eWd2Zc31PddZo7xPIG2KDQBShIk7LpHzgffjQCDkdRE
 id: microsite-anonymous
 label: Anonymous
 weight: -102
@@ -10,4 +13,5 @@ internal: true
 audience: anonymous
 group_type: microsite
 permissions_ui: true
-permissions: {  }
+permissions:
+  - 'view group_node:localgov_page entity'

--- a/config/install/group.role.microsite-anonymous.yml
+++ b/config/install/group.role.microsite-anonymous.yml
@@ -1,11 +1,8 @@
-uuid: 823d5541-f8ce-4eda-9958-06c87a885a49
 langcode: en
 status: true
 dependencies:
   config:
     - group.type.microsite
-_core:
-  default_config_hash: eWd2Zc31PddZo7xPIG2KDQBShIk7LpHzgffjQCDkdRE
 id: microsite-anonymous
 label: Anonymous
 weight: -102

--- a/config/install/group.role.microsite-member.yml
+++ b/config/install/group.role.microsite-member.yml
@@ -1,11 +1,8 @@
-uuid: 57a049d0-21f1-4322-b83a-deb47bf26127
 langcode: en
 status: true
 dependencies:
   config:
     - group.type.microsite
-_core:
-  default_config_hash: bMYdgL38JTzQMAUHLvbsXDCxwCRs_1yXt7fLSKqJ8gE
 id: microsite-member
 label: Member
 weight: -100

--- a/config/install/group.role.microsite-member.yml
+++ b/config/install/group.role.microsite-member.yml
@@ -1,8 +1,11 @@
+uuid: 57a049d0-21f1-4322-b83a-deb47bf26127
 langcode: en
 status: true
 dependencies:
   config:
     - group.type.microsite
+_core:
+  default_config_hash: bMYdgL38JTzQMAUHLvbsXDCxwCRs_1yXt7fLSKqJ8gE
 id: microsite-member
 label: Member
 weight: -100
@@ -10,4 +13,11 @@ internal: true
 audience: member
 group_type: microsite
 permissions_ui: true
-permissions: {  }
+permissions:
+  - 'create group_node:localgov_page entity'
+  - 'update any group_node:localgov_page content'
+  - 'update any group_node:localgov_page entity'
+  - 'update own group_node:localgov_page content'
+  - 'update own group_node:localgov_page entity'
+  - 'view group_node:localgov_page entity'
+  - 'view unpublished group_node:localgov_page entity'

--- a/config/install/group.role.microsite-outsider.yml
+++ b/config/install/group.role.microsite-outsider.yml
@@ -1,11 +1,8 @@
-uuid: 0d3f7371-59a6-4513-89e9-6c468cefac69
 langcode: en
 status: true
 dependencies:
   config:
     - group.type.microsite
-_core:
-  default_config_hash: RTZ4h1O-v-wzefc_CQNX7Po-ox0I1NdEUQGDVeHI-yc
 id: microsite-outsider
 label: Outsider
 weight: -101

--- a/config/install/group.role.microsite-outsider.yml
+++ b/config/install/group.role.microsite-outsider.yml
@@ -1,8 +1,11 @@
+uuid: 0d3f7371-59a6-4513-89e9-6c468cefac69
 langcode: en
 status: true
 dependencies:
   config:
     - group.type.microsite
+_core:
+  default_config_hash: RTZ4h1O-v-wzefc_CQNX7Po-ox0I1NdEUQGDVeHI-yc
 id: microsite-outsider
 label: Outsider
 weight: -101
@@ -10,4 +13,5 @@ internal: true
 audience: outsider
 group_type: microsite
 permissions_ui: true
-permissions: {  }
+permissions:
+  - 'view group_node:localgov_page entity'


### PR DESCRIPTION
So this just adds the default permissions for roles in the group for localgov_page so it rolls out working as expected for now.

Follow-up #20 if we aren't going to have localgov_page always installed. That said it doesn't seem to create a dependency nor get upset if there is a permission for something not there; but that's probably not ideal.