### PR TITLE
Patch to group module to check create in addtion to add permissions for node to group.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,9 @@
     "patches": {
       "drupal/group_content_menu": {
         "Menu item create permisson #3280653": "https://www.drupal.org/files/issues/2022-05-16/3280653-01-menu-item-add-permission.patch"
+      },
+      "drupal/group": {
+        "Empty page when trying to create group node localgovdrupal/localgov_microsites_group#45": "https://www.drupal.org/files/issues/2019-01-04/2842630-20.patch"
       }
     }
   }


### PR DESCRIPTION
It's a patch so requires composer install.

Fixes https://github.com/localgovdrupal/localgov_microsites_group/issues/45

But we should write tests for it for group module and post to
https://www.drupal.org/project/group/issues/2842630 to get it committed.
Other issues on #45 can be referenced as I'm sure they're all dupes.

