### PR TITLE
Add patch from https://www.drupal.org/project/group/issues/3210808

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "Menu item create permisson #3280653": "https://www.drupal.org/files/issues/2022-05-16/3280653-01-menu-item-add-permission.patch"
       },
       "drupal/group": {
-        "Empty page when trying to create group node localgovdrupal/localgov_microsites_group#45": "https://www.drupal.org/files/issues/2019-01-04/2842630-20.patch"
+        "Empty page when trying to create group node localgovdrupal/localgov_microsites_group#45": "https://www.drupal.org/files/issues/2019-01-04/2842630-20.patch",
+	"Fix Deprecated function: uasort() when editing group node view.": "https://www.drupal.org/files/issues/2021-04-26/uasort-comparison-3210808-2.patch"
       }
     }
   }

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
       },
       "drupal/group": {
         "Empty page when trying to create group node localgovdrupal/localgov_microsites_group#45": "https://www.drupal.org/files/issues/2019-01-04/2842630-20.patch",
-	"Fix Deprecated function: uasort() when editing group node view.": "https://www.drupal.org/files/issues/2021-04-26/uasort-comparison-3210808-2.patch"
+        "Fix Deprecated function: uasort() when editing group node view. See https://www.drupal.org/node/3210808 ": "https://www.drupal.org/files/issues/2021-04-26/uasort-comparison-3210808-2.patch"
       }
     }
   }


### PR DESCRIPTION
This patch suppresses the "Deprecated function: uasort():" error outlined in https://github.com/localgovdrupal/localgov_microsites/issues/112