### PR TITLE
Don't use two step for adding Node Page GroupContent.

### DIFF
--- a/config/optional/group.content_type.group_content_type_1a9b2b47fec9e.yml
+++ b/config/optional/group.content_type.group_content_type_1a9b2b47fec9e.yml
@@ -15,4 +15,4 @@ content_plugin: 'group_node:localgov_page'
 plugin_config:
   group_cardinality: 0
   entity_cardinality: 1
-  use_creation_wizard: true
+  use_creation_wizard: false


### PR DESCRIPTION
No additional fields. Alias will be set with domain_path see #146