### PR TITLE
Domain Group settings form

### DIFF
--- a/config/install/group.role.microsite-admin.yml
+++ b/config/install/group.role.microsite-admin.yml
@@ -13,6 +13,7 @@ permissions_ui: true
 permissions:
   - 'access group content menu overview'
   - 'access group_node overview'
+  - 'administer group domain site settings'
   - 'administer members'
   - 'create group_node:localgov_page entity'
   - 'delete any group_node:localgov_page content'

--- a/config/install/user.role.microsites_controller.yml
+++ b/config/install/user.role.microsites_controller.yml
@@ -7,6 +7,7 @@ dependencies:
     - media.type.remote_video
   module:
     - domain
+    - domain_group
     - group
     - media
     - system
@@ -25,6 +26,7 @@ permissions:
   - 'administer domains'
   - 'administer media'
   - 'administer users'
+  - 'bypass domain group permissions'
   - 'bypass group access'
   - 'cancel account'
   - 'change own username'

--- a/src/Form/DomainGroupConfigAdd.php
+++ b/src/Form/DomainGroupConfigAdd.php
@@ -83,14 +83,14 @@ class DomainGroupConfigAdd extends FormBase {
       '#title' => $this->t('@group_label - Domain Settings', ['@group_label' => $group->label()]),
     ];
 
-    // @todo Make plugin and visible fields configurable.
-    // https://github.com/localgovdrupal/localgov_microsites_group/issues/15
+    $plugin = $this->pluginManagerDomainGroupSettings->createInstance('domain_group_domain');
+    $form += $plugin->buildConfigurationForm([], $form_state, $group);
     $plugin = $this->pluginManagerDomainGroupSettings->createInstance('domain_group_site_settings');
     $form += $plugin->buildConfigurationForm([], $form_state, $group);
 
     // Hide non-necessary configuration options.
     $form['error_page']['#access'] = FALSE;
-    $form['site_front_page']['#type'] = 'value';
+    $form['site_frontpage']['#type'] = 'value';
     $form['site_name']['#access'] = FALSE;
     $form['site_slogan']['#access'] = FALSE;
 
@@ -181,9 +181,11 @@ class DomainGroupConfigAdd extends FormBase {
 
     $content = $this->defaultContent->generate($group);
     $front_page = $content['node']['localgov_page'][0];
-    $form_state->setValue('site_front_page', $front_page->toUrl()->toString());
+    $form_state->setValue('site_frontpage', $front_page->toUrl()->toString());
 
     $form_state->set('group', $group);
+    $plugin = $this->pluginManagerDomainGroupSettings->createInstance('domain_group_domain');
+    $plugin->submitConfigurationForm($form, $form_state);
     $plugin = $this->pluginManagerDomainGroupSettings->createInstance('domain_group_site_settings');
     $plugin->submitConfigurationForm($form, $form_state);
 


### PR DESCRIPTION
Working with https://git.drupalcode.org/issue/3278349-3293374/-/merge_requests/1
Makes changes to work with the now two form plugins.
Adds permissions so that controller can access all of the form on all groups, and site admin can access the site settings part of the form localgovdrupal/localgov_microsites#157
