### PR TITLE
Permissions from https://github.com/localgovdrupal/localgov_microsites/pull/175#pullrequestreview-1032762388

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
   "license": "GPL-2.0-or-later",
   "require": {
     "drupal/core": "^9",
+    "drupal/domain_path": "1.x-dev#33fde0b",
     "drupal/field_formatter_class": "^1.5",
     "drupal/group": "^1.4",
     "drupal/group_content_menu": "^1.1",

--- a/config/install/user.role.microsites_controller.yml
+++ b/config/install/user.role.microsites_controller.yml
@@ -8,6 +8,7 @@ dependencies:
   module:
     - domain
     - domain_group
+    - domain_path
     - group
     - media
     - system
@@ -39,6 +40,7 @@ permissions:
   - 'edit any document media'
   - 'edit any image media'
   - 'edit any remote_video media'
+  - 'edit domain path entity'
   - 'edit own document media'
   - 'edit own image media'
   - 'edit own remote_video media'

--- a/config/install/user.role.microsites_trusted_editor.yml
+++ b/config/install/user.role.microsites_trusted_editor.yml
@@ -8,6 +8,7 @@ dependencies:
   module:
     - media
     - system
+    - domain_path
 id: microsites_trusted_editor
 label: 'Microsites trusted editor'
 weight: 3
@@ -24,6 +25,7 @@ permissions:
   - 'edit any document media'
   - 'edit any image media'
   - 'edit any remote_video media'
+  - 'edit domain path entity'
   - 'edit own document media'
   - 'edit own image media'
   - 'edit own remote_video media'

--- a/localgov_microsites_group.info.yml
+++ b/localgov_microsites_group.info.yml
@@ -13,6 +13,7 @@ dependencies:
   - admin_toolbar:admin_toolbar
   - domain:domain
   - domain_group:domain_group
+  - domain_path:domain_path
   - field_group:field_group
   - group:group
   - group:gnode


### PR DESCRIPTION
Not sure I'm happy with adding the dependency on localgov_microsites_group when it's not really needed. Should these roles maybe be in the profile? With the modules that add permissions to them silently not doing so if they don't exist?

Can't do that because we rely on them too much more? Would the hook work in the profile. It's installed before everything else I think? What's profile / starterkit -- and what's (which) module?