### PR TITLE
Don't use two step form for nodes.

### DIFF
--- a/modules/localgov_microsites_directories/config/install/group.content_type.group_content_type_c9da38b716c27.yml
+++ b/modules/localgov_microsites_directories/config/install/group.content_type.group_content_type_c9da38b716c27.yml
@@ -15,4 +15,4 @@ content_plugin: 'group_node:localgov_directory'
 plugin_config:
   group_cardinality: 0
   entity_cardinality: 1
-  use_creation_wizard: true
+  use_creation_wizard: false

--- a/modules/localgov_microsites_directories/config/install/group.content_type.group_content_type_cc7fec428807b.yml
+++ b/modules/localgov_microsites_directories/config/install/group.content_type.group_content_type_cc7fec428807b.yml
@@ -15,4 +15,4 @@ content_plugin: 'group_node:localgov_directories_page'
 plugin_config:
   group_cardinality: 0
   entity_cardinality: 1
-  use_creation_wizard: true
+  use_creation_wizard: false


### PR DESCRIPTION
Small one I noticed a couple of content types still using the two-step form.