### PR TITLE
Toggle permissions tweaks

### DIFF
--- a/src/GroupPermissionsHelper.php
+++ b/src/GroupPermissionsHelper.php
@@ -97,7 +97,7 @@ class GroupPermissionsHelper implements GroupPermissionsHelperInterface {
         continue;
       }
       foreach ($role_permissions['group'] as $role => $permissions) {
-        $shared_permissions[$role] = $shared_permissions[$role] ?? [] + array_intersect($module_permissions['group'][$role], $permissions);
+        $shared_permissions[$role] = array_merge($shared_permissions[$role] ?? [], array_intersect($module_permissions['group'][$role], $permissions));
       }
     }
 
@@ -178,7 +178,7 @@ class GroupPermissionsHelper implements GroupPermissionsHelperInterface {
         $module_permissions = RolesHelper::getModuleRoles($module);
         if (!empty($module_permissions['group'])) {
           foreach ($module_permissions['group'] as $role => $permissions) {
-            $enable_permissions[$role] = $enable_permissions[$role] ?? [] + $permissions;
+            $enable_permissions[$role] = array_merge($enable_permissions[$role] ?? [], $permissions);
           }
         }
       }
@@ -215,7 +215,7 @@ class GroupPermissionsHelper implements GroupPermissionsHelperInterface {
         $module_permissions = RolesHelper::getModuleRoles($module);
         if (!empty($module_permissions['group'])) {
           foreach ($module_permissions['group'] as $role => $permissions) {
-            $permissions_with[$role] = $permissions_with[$role] ?? [] + $permissions;
+            $permissions_with[$role] = array_merge($permissions_with[$role] ?? [], $permissions);
           }
         }
       }

--- a/src/Plugin/DomainGroupSettings/ContentTypeSettings.php
+++ b/src/Plugin/DomainGroupSettings/ContentTypeSettings.php
@@ -126,7 +126,9 @@ class ContentTypeSettings extends DomainGroupSettingsBase implements ContainerFa
           '#type' => 'submit',
           '#value' => $status == GroupPermissionsHelperInterface::ENABLED ? $this->t('Disable') : $this->t('Enable'),
           '#name' => $module_name,
-          '#submit' => $status == GroupPermissionsHelperInterface::ENABLED ? [[$this, 'disableModule']] : [[$this, 'enableModule']],
+          '#submit' => $status == GroupPermissionsHelperInterface::ENABLED ?
+            [[$this, 'disableModule']] :
+            [[$this, 'enableModule']],
         ];
       }
     }
@@ -146,18 +148,26 @@ class ContentTypeSettings extends DomainGroupSettingsBase implements ContainerFa
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
   }
 
+  /**
+   * Form submission handler: Enable module.
+   */
   public function enableModule(array &$form, FormStateInterface $form_state) {
     $module = $form_state->getTriggeringElement()['#name'];
     $this->groupPermissionsHelper->moduleEnable($module, $this->group);
     $info = $this->moduleExtensionList->getExtensionInfo($module);
+    // @codingStandardsIgnoreLine
     $name = $this->t($info['name']);
     $this->messenger()->addMessage($this->t('Enabled: %name', ['%name' => $name]));
   }
 
+  /**
+   * Form submission handler: Disable module.
+   */
   public function disableModule(array &$form, FormStateInterface $form_state) {
     $module = $form_state->getTriggeringElement()['#name'];
     $this->groupPermissionsHelper->moduleDisable($module, $this->group);
     $info = $this->moduleExtensionList->getExtensionInfo($module);
+    // @codingStandardsIgnoreLine
     $name = $this->t($info['name']);
     $this->messenger()->addMessage($this->t('Disabled: %name', ['%name' => $name]));
   }

--- a/src/Plugin/DomainGroupSettings/ContentTypeSettings.php
+++ b/src/Plugin/DomainGroupSettings/ContentTypeSettings.php
@@ -101,7 +101,6 @@ class ContentTypeSettings extends DomainGroupSettingsBase implements ContainerFa
         $this->t('Modules'),
         [
           'data' => $this->t('Enabled'),
-          'class' => ['checkbox'],
         ],
       ],
       '#id' => 'modules',
@@ -122,12 +121,14 @@ class ContentTypeSettings extends DomainGroupSettingsBase implements ContainerFa
         // @codingStandardsIgnoreLine
         $form['modules'][$module_name]['module']['#context']['description'] = $this->t($module['description']);
       }
-      $form['modules'][$module_name]['enabled'] = [
-        '#type' => 'checkbox',
-        '#title' => $this->t('Enabled'),
-        '#default_value' => $status == GroupPermissionsHelperInterface::ENABLED,
-        '#disabled' => $status == GroupPermissionsHelperInterface::UNKNOWN,
-      ];
+      if ($status != GroupPermissionsHelperInterface::UNKNOWN) {
+        $form['modules'][$module_name]['enabled'] = [
+          '#type' => 'submit',
+          '#value' => $status == GroupPermissionsHelperInterface::ENABLED ? $this->t('Disable') : $this->t('Enable'),
+          '#name' => $module_name,
+          '#submit' => $status == GroupPermissionsHelperInterface::ENABLED ? [[$this, 'disableModule']] : [[$this, 'enableModule']],
+        ];
+      }
     }
 
     return $form;
@@ -143,36 +144,22 @@ class ContentTypeSettings extends DomainGroupSettingsBase implements ContainerFa
    * {@inheritdoc}
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
-    $disabled = [];
-    $enabled = [];
-    foreach ($form_state->getValue('modules') as $module => $status) {
-      if ($status['enabled'] && $this->groupPermissionsHelper->moduleStatus($module, $this->group) == GroupPermissionsHelperInterface::DISABLED) {
-        $this->groupPermissionsHelper->moduleEnable($module, $this->group);
-        $enabled[] = $module;
-      }
-      elseif (!$status['enabled'] && $this->groupPermissionsHelper->moduleStatus($module, $this->group) == GroupPermissionsHelperInterface::ENABLED) {
-        $this->groupPermissionsHelper->moduleDisable($module, $this->group);
-        $disabled[] = $module;
-      }
-    }
+  }
 
-    if (!empty($enabled)) {
-      array_walk($enabled, function (&$module) {
-        $info = $this->moduleExtensionList->getExtensionInfo($module);
-        // @codingStandardsIgnoreLine
-        $module = $this->t($info['name']);
-      });
-      $this->messenger()->addMessage($this->t('Enabled: %list', ['%list' => implode(',', $enabled)]));
-    }
-    if (!empty($disabled)) {
-      array_walk($disabled, function (&$module) {
-        $info = $this->moduleExtensionList->getExtensionInfo($module);
-        // @codingStandardsIgnoreLine
-        $module = $this->t($info['name']);
-      });
-      $this->messenger()->addMessage($this->t('Disabled: %list', ['%list' => implode(',', $disabled)]));
-    }
+  public function enableModule(array &$form, FormStateInterface $form_state) {
+    $module = $form_state->getTriggeringElement()['#name'];
+    $this->groupPermissionsHelper->moduleEnable($module, $this->group);
+    $info = $this->moduleExtensionList->getExtensionInfo($module);
+    $name = $this->t($info['name']);
+    $this->messenger()->addMessage($this->t('Enabled: %name', ['%name' => $name]));
+  }
 
+  public function disableModule(array &$form, FormStateInterface $form_state) {
+    $module = $form_state->getTriggeringElement()['#name'];
+    $this->groupPermissionsHelper->moduleDisable($module, $this->group);
+    $info = $this->moduleExtensionList->getExtensionInfo($module);
+    $name = $this->t($info['name']);
+    $this->messenger()->addMessage($this->t('Disabled: %name', ['%name' => $name]));
   }
 
 }

--- a/tests/src/Functional/ModuleSettingsFormTest.php
+++ b/tests/src/Functional/ModuleSettingsFormTest.php
@@ -84,18 +84,22 @@ class ModuleSettingsFormTest extends BrowserTestBase {
     $this->drupalGet('group/' . $group->id() . '/domain-settings');
     $this->assertSession()->pageTextContains($group->label() . ' - Domain Settings');
     $page = $this->getSession()->getPage();
-    $page->hasCheckedField('modules[localgov_microsites_events][enabled]');
-    $page->hasCheckedField('modules[localgov_microsites_directories][enabled]');
-    $page->uncheckField('modules[localgov_microsites_directories][enabled]');
-    $page->pressButton('Submit');
+    $directories = $page->findButton('localgov_microsites_directories');
+    $this->assertEquals('Disable', $directories->getValue());
+    $events = $page->findButton('localgov_microsites_events');
+    $this->assertEquals('Disable', $events->getValue());
+    $directories->press();
 
-    $page->hasCheckedField('modules[localgov_microsites_events][enabled]');
-    $page->hasUncheckedField('modules[localgov_microsites_directories][enabled]');
-    $page->checkField('modules[localgov_microsites_directories][enabled]');
-    $page->pressButton('Submit');
+    $directories = $page->findButton('localgov_microsites_directories');
+    $this->assertEquals('Enable', $directories->getValue());
+    $events = $page->findButton('localgov_microsites_events');
+    $this->assertEquals('Disable', $events->getValue());
+    $directories->press();
 
-    $page->hasCheckedField('modules[localgov_microsites_events][enabled]');
-    $page->hasCheckedField('modules[localgov_microsites_directories][enabled]');
+    $directories = $page->findButton('localgov_microsites_directories');
+    $this->assertEquals('Disable', $directories->getValue());
+    $events = $page->findButton('localgov_microsites_events');
+    $this->assertEquals('Disable', $events->getValue());
 
     $this->drupalLogin($this->memberUser);
     $this->drupalGet('group/' . $group->id() . '/domain-settings');


### PR DESCRIPTION
Fixes:-

  https://github.com/localgovdrupal/localgov_microsites_group/commit/a6ec1f864e49a0d976f2495247581d8d50ec6850 The quirky behaviour between news and events being enabled/disabled
 https://github.com/localgovdrupal/localgov_microsites_group/commit/46d3484c7b0b9b67a88b09c05dbcde7fb038de3f Make it so only one module at a time can be enabled/disabled by using a submit button instead, this simplifies and removes some other quirks.

Related change to Domain Group module:-

 https://git.drupalcode.org/sandbox/ekes-3278349/-/commit/38e34a9615ab62292a45a0c146a67504a6e1b3b4 Fixes the site name or other settings disappearing on save
[that will require updating the Domain Group module obviously]