### PR TITLE
Added cache invalidation for menu changes

### DIFF
--- a/localgov_microsites_group.module
+++ b/localgov_microsites_group.module
@@ -93,8 +93,16 @@ function localgov_microsites_group_entity_extra_field_info() {
  */
 function localgov_microsites_group_menu_link_content_presave(MenuLinkContentInterface $entity) {
 
-  // Clear group cache so menu links are visible.
+  // Find active group.
   $group_id = \Drupal::service('domain_group_resolver')->getActiveDomainGroupId();
+  if (is_null($group_id)) {
+    $group = \Drupal::request()->attributes->get('group');
+    if ($group) {
+      $group_id = $group->id();
+    }
+  }
+
+  // Clear group cache so menu links are visible.
   if ($group_id) {
     Cache::invalidateTags(['group:' . $group_id]);
   }

--- a/localgov_microsites_group.module
+++ b/localgov_microsites_group.module
@@ -18,6 +18,7 @@ use Drupal\localgov_microsites_group\Form\DomainGroupAdd;
 use Drupal\localgov_microsites_group\Form\DomainGroupContentAdd;
 use Drupal\localgov_microsites_group\GroupExtraFieldDisplay;
 use Drupal\localgov_microsites_group\RolesHelper;
+use Drupal\menu_link_content\MenuLinkContentInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
@@ -88,12 +89,15 @@ function localgov_microsites_group_entity_extra_field_info() {
 }
 
 /**
- * Implements hook_ENTITY_TYPE_presave().
+ * Implements hook_ENTITY_TYPE_presave() for menu_link_content entities.
  */
-function localgov_microsites_group_group_presave(GroupInterface $entity) {
+function localgov_microsites_group_menu_link_content_presave(MenuLinkContentInterface $entity) {
 
-  // Clear node cache so site design changes become visible.
-  Cache::invalidateTags(['node_view']);
+  // Clear group cache so menu links are visible.
+  $group_id = \Drupal::service('domain_group_resolver')->getActiveDomainGroupId();
+  if ($group_id) {
+    Cache::invalidateTags(['group:' . $group_id]);
+  }
 }
 
 /**

--- a/tests/src/Functional/MicrositeCachingTest.php
+++ b/tests/src/Functional/MicrositeCachingTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Drupal\Tests\localgov_microsites_group\Functional;
+
+use Drupal\group\Entity\GroupInterface;
+use Drupal\node\NodeInterface;
+use Drupal\search_api\Entity\Index;
+use Drupal\Tests\domain_group\Traits\GroupCreationTrait;
+use Drupal\Tests\domain_group\Traits\InitializeGroupsTrait;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\node\Traits\NodeCreationTrait;
+
+/**
+ * Tests caching of site settings.
+ *
+ * @group localgov_microsites_group
+ */
+class MicrositeCachingTest extends BrowserTestBase {
+
+  use GroupCreationTrait;
+  use InitializeGroupsTrait;
+  use NodeCreationTrait;
+
+  /**
+   * Will be removed when issue #3204455 on Domain Site Settings gets merged.
+   *
+   * See https://www.drupal.org/project/domain_site_settings/issues/3204455.
+   *
+   * @var bool
+   *
+   * @see \Drupal\Core\Config\Development\ConfigSchemaChecker
+   * phpcs:disable DrupalPractice.Objects.StrictSchemaDisabled.StrictConfigSchema
+   */
+  protected $strictConfigSchema = FALSE;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $profile = 'localgov_microsites';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'localgov_microsites_base';
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'localgov_microsites_group',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Set base hostname.
+    $this->setBaseHostname();
+
+    // Create some microsites.
+    $this->group = $this->createGroup([
+      'label' => 'group-a1',
+      'type' => 'microsite',
+    ]);
+    $this->domain = \Drupal::entityTypeManager()->getStorage('domain')->create([
+      'id' => 'group_' . $this->group->id(),
+      'name' => $this->group->label(),
+      'hostname' => $this->group->label() . '.' . $this->baseHostname,
+      'third_party_settings' => [
+        'domain_group' => ['group' =>  $this->group->id()],
+      ],
+    ]);
+    $this->domain->save();
+
+    // Login as admin user.
+    $this->drupalLogin($this->drupalCreateUser([], NULL, TRUE));
+  }
+
+  /**
+   * Test changes to site settings.
+   */
+  public function testSiteSettings() {
+
+    // Check changes to footer blocks.
+    $footer_text = $this->randomString();
+    $this->drupalGet('group/' . $this->group->id() . '/edit');
+    $this->submitForm([
+      'lgms_footer_text_block_1[0][value]' => $footer_text,
+    ], 'Save');
+    $this->drupalGet($this->domain->getUrl());
+    $this->assertSession()->pageTextContains($footer_text);
+
+    // Check menu changes appear
+    $link_title = $this->randomString();
+    $this->drupalGet('group/' . $this->group->id() . '/menu/2/add-link');
+    $this->submitForm([
+      'title[0][value]' => $link_title,
+      'link[0][uri]' => '<front>',
+    ], 'Save');
+    $this->drupalGet($this->domain->getUrl());
+    $this->assertSession()->pageTextContains($link_title);
+  }
+}

--- a/tests/src/Functional/MicrositeCachingTest.php
+++ b/tests/src/Functional/MicrositeCachingTest.php
@@ -2,9 +2,6 @@
 
 namespace Drupal\Tests\localgov_microsites_group\Functional;
 
-use Drupal\group\Entity\GroupInterface;
-use Drupal\node\NodeInterface;
-use Drupal\search_api\Entity\Index;
 use Drupal\Tests\domain_group\Traits\GroupCreationTrait;
 use Drupal\Tests\domain_group\Traits\InitializeGroupsTrait;
 use Drupal\Tests\BrowserTestBase;
@@ -69,7 +66,7 @@ class MicrositeCachingTest extends BrowserTestBase {
       'name' => $this->group->label(),
       'hostname' => $this->group->label() . '.' . $this->baseHostname,
       'third_party_settings' => [
-        'domain_group' => ['group' =>  $this->group->id()],
+        'domain_group' => ['group' => $this->group->id()],
       ],
     ]);
     $this->domain->save();
@@ -92,7 +89,7 @@ class MicrositeCachingTest extends BrowserTestBase {
     $this->drupalGet($this->domain->getUrl());
     $this->assertSession()->pageTextContains($footer_text);
 
-    // Check menu changes appear
+    // Check menu changes appear.
     $link_title = $this->randomString();
     $this->drupalGet('group/' . $this->group->id() . '/menu/2/add-link');
     $this->submitForm([
@@ -102,4 +99,5 @@ class MicrositeCachingTest extends BrowserTestBase {
     $this->drupalGet($this->domain->getUrl());
     $this->assertSession()->pageTextContains($link_title);
   }
+
 }


### PR DESCRIPTION
Also removes unneeded cache invalidation for group setting changes. It looks like things have changed since #94 was implemented so the correct cache tags are invalidated when group settings are saved. I've added a test to check it's not required. 

Fixes #94
Fixes #203