### PR TITLE
Fix #217 add domain_group process to restrict search api results

### DIFF
--- a/config/install/core.entity_form_display.group.microsite.default.yml
+++ b/config/install/core.entity_form_display.group.microsite.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.group.microsite.lgms_base_line_height
     - field.field.group.microsite.lgms_base_spacing
     - field.field.group.microsite.lgms_body_font
+    - field.field.group.microsite.lgms_favicon
     - field.field.group.microsite.lgms_footer_background_colour
     - field.field.group.microsite.lgms_footer_banner
     - field.field.group.microsite.lgms_footer_copyright_notice
@@ -88,6 +89,7 @@ dependencies:
     - group.type.microsite
   module:
     - field_group
+    - file
     - media_library
     - path
     - text
@@ -457,6 +459,13 @@ content:
     weight: 11
     region: content
     settings: {  }
+    third_party_settings: {  }
+  lgms_favicon:
+    type: file_generic
+    weight: 33
+    region: content
+    settings:
+      progress_indicator: throbber
     third_party_settings: {  }
   lgms_footer_background_colour:
     type: string_textfield

--- a/config/install/core.entity_form_display.group.microsite.new_domain.yml
+++ b/config/install/core.entity_form_display.group.microsite.new_domain.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.group.microsite.lgms_base_line_height
     - field.field.group.microsite.lgms_base_spacing
     - field.field.group.microsite.lgms_body_font
+    - field.field.group.microsite.lgms_favicon
     - field.field.group.microsite.lgms_footer_background_colour
     - field.field.group.microsite.lgms_footer_banner
     - field.field.group.microsite.lgms_footer_copyright_notice
@@ -208,6 +209,7 @@ hidden:
   lgms_base_line_height: true
   lgms_base_spacing: true
   lgms_body_font: true
+  lgms_favicon: true
   lgms_footer_background_colour: true
   lgms_footer_banner: true
   lgms_footer_copyright_notice: true

--- a/config/install/core.entity_view_display.group.microsite.default.yml
+++ b/config/install/core.entity_view_display.group.microsite.default.yml
@@ -6,9 +6,11 @@ dependencies:
     - field.field.group.microsite.lgms_base_line_height
     - field.field.group.microsite.lgms_base_spacing
     - field.field.group.microsite.lgms_body_font
+    - field.field.group.microsite.lgms_favicon
     - field.field.group.microsite.lgms_footer_background_colour
     - field.field.group.microsite.lgms_footer_banner
     - field.field.group.microsite.lgms_footer_copyright_notice
+    - field.field.group.microsite.lgms_footer_items_alignment
     - field.field.group.microsite.lgms_footer_link_colour
     - field.field.group.microsite.lgms_footer_link_hover_colour
     - field.field.group.microsite.lgms_footer_logos
@@ -22,6 +24,7 @@ dependencies:
     - field.field.group.microsite.lgms_header_link_colour
     - field.field.group.microsite.lgms_header_link_hover_colour
     - field.field.group.microsite.lgms_header_text_colour
+    - field.field.group.microsite.lgms_header_vertical_alignment
     - field.field.group.microsite.lgms_header_width
     - field.field.group.microsite.lgms_heading_1_font
     - field.field.group.microsite.lgms_heading_1_font_colour
@@ -57,6 +60,11 @@ dependencies:
     - field.field.group.microsite.lgms_heading_font_weight
     - field.field.group.microsite.lgms_link_colour
     - field.field.group.microsite.lgms_main_logo
+    - field.field.group.microsite.lgms_main_menu_font_size
+    - field.field.group.microsite.lgms_main_menu_font_weight
+    - field.field.group.microsite.lgms_off_canvas_bg_colour
+    - field.field.group.microsite.lgms_off_canvas_menu_icon
+    - field.field.group.microsite.lgms_off_canvas_text_colour
     - field.field.group.microsite.lgms_page_background_colour
     - field.field.group.microsite.lgms_powered_by
     - field.field.group.microsite.lgms_pre_header_bg_colour
@@ -69,7 +77,13 @@ dependencies:
     - field.field.group.microsite.lgms_secondary_colour
     - field.field.group.microsite.lgms_secondary_colour_contrast
     - field.field.group.microsite.lgms_site_name
+    - field.field.group.microsite.lgms_site_name_font_size
+    - field.field.group.microsite.lgms_site_name_font_weight
     - field.field.group.microsite.lgms_site_slogan
+    - field.field.group.microsite.lgms_submenu_background_colour
+    - field.field.group.microsite.lgms_submenu_icon
+    - field.field.group.microsite.lgms_submenu_icon_rotation
+    - field.field.group.microsite.lgms_submenu_link_colour
     - field.field.group.microsite.lgms_teaser_image_style
     - field.field.group.microsite.lgms_text_colour
     - group.type.microsite
@@ -98,9 +112,11 @@ hidden:
   lgms_base_line_height: true
   lgms_base_spacing: true
   lgms_body_font: true
+  lgms_favicon: true
   lgms_footer_background_colour: true
   lgms_footer_banner: true
   lgms_footer_copyright_notice: true
+  lgms_footer_items_alignment: true
   lgms_footer_link_colour: true
   lgms_footer_link_hover_colour: true
   lgms_footer_logos: true
@@ -114,6 +130,7 @@ hidden:
   lgms_header_link_colour: true
   lgms_header_link_hover_colour: true
   lgms_header_text_colour: true
+  lgms_header_vertical_alignment: true
   lgms_header_width: true
   lgms_heading_1_font: true
   lgms_heading_1_font_colour: true
@@ -149,6 +166,11 @@ hidden:
   lgms_heading_font_weight: true
   lgms_link_colour: true
   lgms_main_logo: true
+  lgms_main_menu_font_size: true
+  lgms_main_menu_font_weight: true
+  lgms_off_canvas_bg_colour: true
+  lgms_off_canvas_menu_icon: true
+  lgms_off_canvas_text_colour: true
   lgms_page_background_colour: true
   lgms_powered_by: true
   lgms_pre_header_bg_colour: true
@@ -161,7 +183,14 @@ hidden:
   lgms_secondary_colour: true
   lgms_secondary_colour_contrast: true
   lgms_site_name: true
+  lgms_site_name_font_size: true
+  lgms_site_name_font_weight: true
   lgms_site_slogan: true
+  lgms_submenu_background_colour: true
+  lgms_submenu_icon: true
+  lgms_submenu_icon_rotation: true
+  lgms_submenu_link_colour: true
   lgms_teaser_image_style: true
   lgms_text_colour: true
+  search_api_excerpt: true
   uid: true

--- a/config/install/core.entity_view_display.group.microsite.microsite.yml
+++ b/config/install/core.entity_view_display.group.microsite.microsite.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.group.microsite.lgms_base_line_height
     - field.field.group.microsite.lgms_base_spacing
     - field.field.group.microsite.lgms_body_font
+    - field.field.group.microsite.lgms_favicon
     - field.field.group.microsite.lgms_footer_background_colour
     - field.field.group.microsite.lgms_footer_banner
     - field.field.group.microsite.lgms_footer_copyright_notice
@@ -201,6 +202,7 @@ hidden:
   lgms_base_line_height: true
   lgms_base_spacing: true
   lgms_body_font: true
+  lgms_favicon: true
   lgms_footer_background_colour: true
   lgms_footer_items_alignment: true
   lgms_footer_link_colour: true

--- a/config/install/field.field.group.microsite.lgms_favicon.yml
+++ b/config/install/field.field.group.microsite.lgms_favicon.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.group.lgms_favicon
+    - group.type.microsite
+  module:
+    - file
+id: group.microsite.lgms_favicon
+field_name: lgms_favicon
+entity_type: group
+bundle: microsite
+label: Icon
+description: 'An image here will be used to override the default favicon for the site.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:file'
+  handler_settings: {  }
+  file_directory: favicon
+  file_extensions: png
+  max_filesize: ''
+  description_field: false
+field_type: file

--- a/config/install/field.storage.group.lgms_favicon.yml
+++ b/config/install/field.storage.group.lgms_favicon.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - file
+    - group
+id: group.lgms_favicon
+field_name: lgms_favicon
+entity_type: group
+type: file
+settings:
+  target_type: file
+  display_field: false
+  display_default: false
+  uri_scheme: public
+module: file
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/localgov_microsites_group.install
+++ b/localgov_microsites_group.install
@@ -2,7 +2,7 @@
 
 /**
  * @file
- * LocalGov Microsites Directories install file.
+ * LocalGov Microsites Group install file.
  */
 
 use Drupal\search_api\Entity\Index;
@@ -10,17 +10,14 @@ use Drupal\search_api\Entity\Index;
 /**
  * Implements hook_install().
  */
-function localgov_microsites_directories_install($is_syncing) {
-
-  // Enabled the directories DB backend after installing dependencies.
-  \Drupal::service('module_installer')->install(['localgov_directories_db']);
+function localgov_microsites_group_install($is_syncing) {
 
   if ($is_syncing) {
     return;
   }
 
   // Add domain access to exclude other sites results.
-  $index = Index::load('localgov_directories_index_default');
+  $index = Index::load('localgov_sitewide_search');
   $processor = \Drupal::getContainer()
     ->get('search_api.plugin_helper')
     ->createProcessorPlugin($index, 'domain_group_entity_access');

--- a/localgov_microsites_group.module
+++ b/localgov_microsites_group.module
@@ -12,6 +12,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Url;
 use Drupal\group\Entity\GroupContentInterface;
 use Drupal\group\Entity\GroupInterface;
+use Drupal\localgov_microsites_group\DomainSettingsHelper;
 use Drupal\localgov_microsites_group\Entity\MicrositeGroup;
 use Drupal\localgov_microsites_group\Entity\MicrositeGroupInterface;
 use Drupal\localgov_microsites_group\Form\DomainGroupAdd;
@@ -115,6 +116,24 @@ function localgov_microsites_group_view(array &$build, GroupInterface $group, En
   return \Drupal::service('class_resolver')
     ->getInstanceFromDefinition(GroupExtraFieldDisplay::class)
     ->groupView($build, $group, $display, $view_mode);
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_insert() for group entities.
+ */
+function localgov_microsites_group_group_insert(GroupInterface $group) {
+  if ($group->hasField('lgms_favicon')) {
+    \Drupal::classResolver(DomainSettingsHelper::class)->faviconField($group, $group->lgms_favicon);
+  }
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_update() for group entities.
+ */
+function localgov_microsites_group_group_update(GroupInterface $group) {
+  if ($group->hasField('lgms_favicon')) {
+    \Drupal::classResolver(DomainSettingsHelper::class)->faviconField($group, $group->lgms_favicon);
+  }
 }
 
 /**

--- a/modules/localgov_microsites_events/localgov_microsites_events.install
+++ b/modules/localgov_microsites_events/localgov_microsites_events.install
@@ -5,6 +5,8 @@
  * LocalGov Microsites Events module file.
  */
 
+use Drupal\search_api\Entity\Index;
+
 /**
  * Implements hook_install().
  */
@@ -246,4 +248,12 @@ function localgov_microsites_events_install($is_syncing) {
     $field->setSetting('handler', 'group:taxonomy_term');
     $field->save();
   }
+
+  // Add domain access to exclude other sites results.
+  $index = Index::load('localgov_events');
+  $processor = \Drupal::getContainer()
+    ->get('search_api.plugin_helper')
+    ->createProcessorPlugin($index, 'domain_group_entity_access');
+  $index->addProcessor($processor);
+  $index->save();
 }

--- a/modules/localgov_microsites_news/localgov_microsites_news.install
+++ b/modules/localgov_microsites_news/localgov_microsites_news.install
@@ -5,6 +5,8 @@
  * LocalGov Microsites News module file.
  */
 
+use Drupal\search_api\Entity\Index;
+
 /**
  * Implements hook_install().
  */
@@ -153,4 +155,12 @@ function localgov_microsites_news_install($is_syncing) {
     ->load('node.localgov_news_article.localgov_news_categories');
   $field->setSetting('handler', 'group:taxonomy_term');
   $field->save();
+
+  // Add domain access to exclude other sites results.
+  $index = Index::load('localgov_news');
+  $processor = \Drupal::getContainer()
+    ->get('search_api.plugin_helper')
+    ->createProcessorPlugin($index, 'domain_group_entity_access');
+  $index->addProcessor($processor);
+  $index->save();
 }

--- a/src/DomainSettingsHelper.php
+++ b/src/DomainSettingsHelper.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Drupal\localgov_microsites_group;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\DependencyInjection\ContainerInjectionInterface;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\domain\DomainInterface;
+use Drupal\domain\DomainStorageInterface;
+use Drupal\file\FileInterface;
+use Drupal\file\Plugin\Field\FieldType\FileFieldItemList;
+use Drupal\group\Entity\GroupInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Associate field data with Domain Settings.
+ *
+ * Most settings are configured using the DomainGroupSettings plugin system.
+ * See Plugin\DomainGroupSettings.
+ * This class helps for values that are saved on the Group entity itself.
+ */
+class DomainSettingsHelper implements ContainerInjectionInterface {
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * The domain entity storage.
+   *
+   * @var \Drupal\domain\DomainStorageInterface
+   */
+  protected $domainStorage;
+
+  /**
+   * The language manager.
+   *
+   * @var \Drupal\language\LanguageManagerInterface
+   */
+  protected $languageManager;
+
+  /**
+   * DomainSettings Helper constructor.
+   *
+   * @param Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   * @param Drupal\domain\DomainStorageInterface $domain_storage
+   *   The domain entity storage.
+   * @param Drupal\language\LanguageManagerInterface $language_manager
+   *   The language manager.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, DomainStorageInterface $domain_storage, LanguageManagerInterface $language_manager) {
+    $this->configFactory = $config_factory;
+    $this->domainStorage = $domain_storage;
+    $this->languageManager = $language_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('entity_type.manager')->getStorage('domain'),
+      $container->get('language_manager')
+    );
+  }
+
+  /**
+   * Handle the favicon file field.
+   */
+  public function faviconField(GroupInterface $group, FileFieldItemList $favicon_field) {
+    if ($domain = $this->getGroupDomain($group)) {
+      $theme = $this->getDomainTheme($domain);
+      if ($favicon_field->isEmpty()) {
+        $this->unsetFavicon($domain, $theme);
+      }
+      else {
+        $this->setFavicon($domain, $theme, $favicon_field->entity);
+      }
+    }
+  }
+
+  /**
+   * Remove any custom favicon override.
+   *
+   * @param \Drupal\Domain\DomainInterface $domain
+   *   The Domain to remove it from.
+   * @param string $theme
+   *   The machine name of the theme.
+   */
+  public function unsetFavicon(DomainInterface $domain, $theme): void {
+    $config_override = $this->loadConfigOverride($domain, $theme . '.settings');
+    $data = $config_override->getRawData();
+    unset($data['favicon']);
+    if (empty($data)) {
+      $config_override->delete();
+    }
+    else {
+      $config_override->setData($data);
+      $config_override->save();
+    }
+  }
+
+  /**
+   * Set a favicon override.
+   *
+   * @param \Drupal\Domain\DomainInterface $domain
+   *   The Domain to add it for.
+   * @param string $theme
+   *   The machine name of the theme.
+   * @param \Drupal\file\FileInterface $favicon_entity
+   *   The favicon file entity.
+   */
+  public function setFavicon(DomainInterface $domain, $theme, FileInterface $favicon_entity) {
+    $config_override = $this->loadConfigOverride($domain, $theme . '.settings');
+    $data = $config_override->getRawData();
+    $data['favicon'] = [
+      'use_default' => 0,
+      'path' => $favicon_entity->getFileUri(),
+      'mimetype' => $favicon_entity->getMimeType(),
+    ];
+    $config_override->setData($data);
+    $config_override->save();
+  }
+
+  /**
+   * Get the Domain for a Group.
+   *
+   * @param \Drupal\group\Entity\GroupInterface $group
+   *   The group.
+   *
+   * @return \Drupal\Domain\DomainInterface
+   *   The related domain.
+   */
+  private function getGroupDomain(GroupInterface $group): ?DomainInterface {
+    return $this->domainStorage->load('group_' . $group->id());
+  }
+
+  /**
+   * Get the current theme for the Domain.
+   *
+   * @param \Drupal\Domain\DomainInterface $domain
+   *   The domain.
+   *
+   * @return string
+   *   The machine name of the domain's current theme.
+   */
+  private function getDomainTheme(DomainInterface $domain): string {
+    $config_override = $this->loadConfigOverride($domain, 'system.theme');
+    if (!$config_override->isNew() && ($theme = $config_override->get('default'))) {
+      return $theme;
+    }
+    else {
+      $site_config = $this->configFactory->get('system.theme');
+      return $site_config->get('default');
+    }
+  }
+
+  /**
+   * Load, or create, domain config override - for language.
+   *
+   * @param \Drupal\domain\DomainInterface $domain
+   *   The domain site configuration being overriden.
+   * @param string $original_config_id
+   *   The configuration to retrieve.
+   *
+   * @return \Drupal\Core\Config\Config
+   *   Editable configuaration.
+   */
+  private function loadConfigOverride(DomainInterface $domain, string $original_config_id) {
+    if ($this->languageManager->getConfigOverrideLanguage() == $this->languageManager->getDefaultLanguage()) {
+      $config_id = 'domain.config.' . $domain->id() . '.' . $original_config_id;
+    }
+    else {
+      $config_id = 'domain.config.' . $domain->id() . '.' . $this->languageManager->getConfigOverrideLanguage() . '.' . $original_config_id;
+    }
+    $config_override = $this->configFactory->getEditable($config_id);
+
+    return $config_override;
+  }
+
+}

--- a/tests/src/Kernel/GroupDefaultContentTest.php
+++ b/tests/src/Kernel/GroupDefaultContentTest.php
@@ -21,9 +21,11 @@ class GroupDefaultContentTest extends GroupKernelTestBase {
    */
   public static $modules = [
     'localgov_microsites_group',
+    'domain',
     'entity_reference_revisions',
     'field_formatter_class',
     'field_group',
+    'file',
     'image',
     'media',
     'media_library',


### PR DESCRIPTION
Requires latest domain_group to test with commit https://git.drupalcode.org/sandbox/ekes-3278349/-/commit/389d3cc0fea7525d10719d69022d7350d0475223

This adds a processor that includes the microsite group with all the indexed items, and then applies a filter by domain to them. I've only manually tested that caching is correct.