### PR TITLE
Fix taxonomy listing view so that it does not require the permission …

### DIFF
--- a/modules/localgov_microsites_group_term_ui/config/install/views.view.lgms_group_taxonomy_terms.yml
+++ b/modules/localgov_microsites_group_term_ui/config/install/views.view.lgms_group_taxonomy_terms.yml
@@ -1,20 +1,22 @@
 langcode: en
 status: true
 dependencies:
+  config:
+    - group.type.microsite
   module:
     - group
     - taxonomy
 id: lgms_group_taxonomy_terms
-label: 'Group taxonomy terms'
-module: group
+label: 'lgms group taxonomy terms'
+module: views
 description: ''
 tag: ''
-base_table: group_relationship_field_data
-base_field: id
+base_table: taxonomy_term_field_data
+base_field: tid
 display:
   default:
     id: default
-    display_title: Master
+    display_title: Default
     display_plugin: default
     position: 0
     display_options:
@@ -24,7 +26,7 @@ display:
           id: name
           table: taxonomy_term_field_data
           field: name
-          relationship: gc__taxonomy_term
+          relationship: none
           group_type: group
           admin_label: ''
           entity_type: taxonomy_term
@@ -34,30 +36,12 @@ display:
           exclude: false
           alter:
             alter_text: false
-            text: ''
             make_link: false
-            path: ''
             absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
+            word_boundary: false
+            ellipsis: false
             strip_tags: false
             trim: false
-            preserve_tags: ''
             html: false
           element_type: ''
           element_class: ''
@@ -86,83 +70,17 @@ display:
           separator: ', '
           field_api_classes: false
           convert_spaces: false
-        weight:
-          id: weight
-          table: taxonomy_term_field_data
-          field: weight
-          relationship: gc__taxonomy_term
-          group_type: group
-          admin_label: ''
-          entity_type: taxonomy_term
-          entity_field: weight
-          plugin_id: field
-          label: Weight
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: number_integer
-          settings:
-            thousand_separator: ''
-            prefix_suffix: true
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
         changed:
           id: changed
           table: taxonomy_term_field_data
           field: changed
-          relationship: gc__taxonomy_term
+          relationship: none
           group_type: group
           admin_label: ''
           entity_type: taxonomy_term
           entity_field: changed
           plugin_id: field
-          label: 'Updated date'
+          label: Updated
           exclude: false
           alter:
             alter_text: false
@@ -219,11 +137,77 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+        weight:
+          id: weight
+          table: taxonomy_term_field_data
+          field: weight
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: weight
+          plugin_id: field
+          label: Weight
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         edit_taxonomy_term:
           id: edit_taxonomy_term
-          table: taxonomy_term_data
+          table: taxonomy_term_field_revision
           field: edit_taxonomy_term
-          relationship: gc__taxonomy_term
+          relationship: none
           group_type: group
           admin_label: ''
           entity_type: taxonomy_term
@@ -270,11 +254,13 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: edit
+          output_url_as_text: false
+          absolute: false
         delete_taxonomy_term:
           id: delete_taxonomy_term
-          table: taxonomy_term_data
+          table: taxonomy_term_field_revision
           field: delete_taxonomy_term
-          relationship: gc__taxonomy_term
+          relationship: none
           group_type: group
           admin_label: ''
           entity_type: taxonomy_term
@@ -321,6 +307,8 @@ display:
           empty_zero: false
           hide_alter_empty: true
           text: delete
+          output_url_as_text: false
+          absolute: false
         dropbutton:
           id: dropbutton
           table: views
@@ -372,24 +360,21 @@ display:
           hide_alter_empty: true
           destination: true
           fields:
-            view_taxonomy_term: view_taxonomy_term
             edit_taxonomy_term: edit_taxonomy_term
             delete_taxonomy_term: delete_taxonomy_term
             name: '0'
-            tid: '0'
-            description__format: '0'
+            changed: '0'
+            weight: '0'
       pager:
-        type: full
+        type: mini
         options:
           offset: 0
-          items_per_page: 50
+          items_per_page: 25
           total_pages: null
           id: 0
           tags:
             next: ››
             previous: ‹‹
-            first: '« First'
-            last: 'Last »'
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'
@@ -398,7 +383,6 @@ display:
             items_per_page_options_all_label: '- All -'
             offset: false
             offset_label: Offset
-          quantity: 9
       exposed_form:
         type: basic
         options:
@@ -426,94 +410,27 @@ display:
           admin_label: ''
           plugin_id: text_custom
           empty: true
-          content: 'No terms available.'
+          content: ''
           tokenize: false
-      sorts:
-        weight:
-          id: weight
-          table: taxonomy_term_field_data
-          field: weight
-          relationship: gc__taxonomy_term
-          group_type: group
-          admin_label: ''
-          entity_type: taxonomy_term
-          entity_field: weight
-          plugin_id: standard
-          order: ASC
-          expose:
-            label: ''
-            field_identifier: ''
-          exposed: false
-        name:
-          id: name
-          table: taxonomy_term_field_data
-          field: name
-          relationship: gc__taxonomy_term
-          group_type: group
-          admin_label: ''
-          entity_type: taxonomy_term
-          entity_field: name
-          plugin_id: standard
-          order: ASC
-          expose:
-            label: ''
-            field_identifier: ''
-          exposed: false
+      sorts: {  }
       arguments:
         gid:
           id: gid
           table: group_relationship_field_data
           field: gid
-          relationship: none
+          relationship: group_relationship
           group_type: group
           admin_label: ''
           entity_type: group_relationship
           entity_field: gid
-          plugin_id: numeric
-          default_action: 'access denied'
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: true
-          title: '{{ arguments.gid|placeholder }} terms'
-          default_argument_type: fixed
-          default_argument_options:
-            argument: ''
-          default_argument_skip_url: false
-          summary_options:
-            base_path: ''
-            count: true
-            override: false
-            items_per_page: 25
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: false
-          validate:
-            type: none
-            fail: 'not found'
-          validate_options: {  }
-          break_phrase: false
-          not: false
-        vid:
-          id: vid
-          table: taxonomy_term_field_data
-          field: vid
-          relationship: gc__taxonomy_term
-          group_type: group
-          admin_label: ''
-          entity_type: taxonomy_term
-          entity_field: vid
-          plugin_id: vocabulary_vid
+          plugin_id: group_id
           default_action: ignore
           exception:
             value: all
             title_enable: false
             title: All
           title_enable: true
-          title: '{{ arguments.vid }} terms'
+          title: ''
           default_argument_type: fixed
           default_argument_options:
             argument: ''
@@ -527,98 +444,36 @@ display:
             sort_order: asc
             number_of_records: 0
             format: default_summary
-          specify_validation: false
+          specify_validation: true
           validate:
-            type: none
+            type: 'entity:group'
             fail: 'not found'
-          validate_options: {  }
+          validate_options:
+            bundles:
+              microsite: microsite
+            access: false
+            operation: view
+            multiple: 0
           break_phrase: false
           not: false
-      filters: {  }
+      filters:
+        status:
+          id: status
+          table: taxonomy_term_field_data
+          field: status
+          entity_type: taxonomy_term
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
       style:
         type: table
-        options:
-          grouping: {  }
-          row_class: ''
-          default_row_class: true
-          columns:
-            name: name
-            group_roles: group_roles
-            changed: changed
-            created: created
-            view_group_relationship: view_group_relationship
-            edit_group_relationship: edit_group_relationship
-            delete_group_relationship: delete_group_relationship
-            dropbutton: dropbutton
-          default: '-1'
-          info:
-            name:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            group_roles:
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            changed:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            created:
-              sortable: true
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            view_group_relationship:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            edit_group_relationship:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            delete_group_relationship:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-            dropbutton:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
-          override: true
-          sticky: true
-          summary: ''
-          empty_table: true
-          caption: ''
-          description: ''
       row:
         type: fields
-        options:
-          default_field_elements: true
-          inline: {  }
-          separator: ''
-          hide_empty: false
       query:
         type: views_query
         options:
@@ -628,22 +483,22 @@ display:
           replica: false
           query_tags: {  }
       relationships:
-        gc__taxonomy_term:
-          id: gc__taxonomy_term
-          table: group_relationship_field_data
-          field: gc__taxonomy_term
+        group_relationship:
+          id: group_relationship
+          table: taxonomy_term_field_data
+          field: group_relationship
           relationship: none
           group_type: group
-          admin_label: 'Group content Taxonomy term'
-          entity_type: group_relationship
-          plugin_id: group_relationship_to_entity
+          admin_label: 'Taxonomy term group relationship'
+          entity_type: taxonomy_term
+          plugin_id: group_relationship_to_entity_reverse
           required: true
-          group_relationship_plugins:
-            'group_term:gtdx_vocab': '0'
-            'group_term:store_tags': '0'
-            'group_term:tags': '0'
-            'group_term:time_period': '0'
-            'group_term:yc_vocab': '0'
+          group_relation_plugins:
+            'group_term:localgov_blog_author': '0'
+            'group_term:localgov_event_category': '0'
+            'group_term:localgov_event_locality': '0'
+            'group_term:localgov_event_price': '0'
+            'group_term:localgov_topic': '0'
       header: {  }
       footer: {  }
       display_extenders: {  }
@@ -665,15 +520,6 @@ display:
     display_options:
       display_extenders: {  }
       path: group/%group/taxonomy/%vid
-      menu:
-        type: tab
-        title: Terms
-        description: ''
-        weight: 20
-        expanded: false
-        menu_name: main
-        parent: ''
-        context: '0'
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
…to view the group releationship entity to view terms.

This should mean that the user no longer needs permissions to view group relationships for the terms in the group, just to see the listed terms.

Happy to merge and test, but figured a pull request helps to share.