### PR TITLE
Feature/235 webforms

### DIFF
--- a/.github/workflows/localgov_microsites.yml
+++ b/.github/workflows/localgov_microsites.yml
@@ -112,7 +112,6 @@ jobs:
         drupal-version:
           - '~9.3'
         php-version:
-          - '7.4'
           - '8.1'
 
     steps:
@@ -148,7 +147,6 @@ jobs:
         drupal-version:
           - '~9.3'
         php-version:
-          - '7.4'
           - '8.1'
 
     steps:
@@ -183,7 +181,6 @@ jobs:
         drupal-version:
           - '~9.3'
         php-version:
-          - '7.4'
           - '8.1'
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "drupal/role_delegation": "^1.2",
     "localgovdrupal/group_webform": "1.x-dev",
     "localgovdrupal/localgov_core": "^2.1.0",
+    "localgovdrupal/localgov_forms": "1.x-dev",
     "localgovdrupal/localgov_page": "^1.0@beta",
     "localgovdrupal/localgov_search": "^1.1"
   },

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     "drupal/override_node_options": "^2.6",
     "drupal/replicate": "^1.0",
     "drupal/role_delegation": "^1.2",
+    "localgovdrupal/group_webform": "1.x-dev",
     "localgovdrupal/localgov_core": "^2.1.0",
     "localgovdrupal/localgov_page": "^1.0@beta",
     "localgovdrupal/localgov_search": "^1.1"

--- a/modules/localgov_microsites_group_webform/config/install/core.entity_form_display.node.localgov_webform.default.yml
+++ b/modules/localgov_microsites_group_webform/config/install/core.entity_form_display.node.localgov_webform.default.yml
@@ -1,0 +1,104 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.localgov_webform.body
+    - field.field.node.localgov_webform.localgov_submission_confirm
+    - field.field.node.localgov_webform.localgov_submission_email
+    - field.field.node.localgov_webform.localgov_webform
+    - node.type.localgov_webform
+  module:
+    - path
+    - text
+    - webform
+id: node.localgov_webform.default
+targetEntityType: node
+bundle: localgov_webform
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 7
+    region: content
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+      show_summary: false
+    third_party_settings: {  }
+  created:
+    type: datetime_timestamp
+    weight: 2
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  localgov_submission_confirm:
+    type: string_textarea
+    weight: 26
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+  localgov_submission_email:
+    type: email_default
+    weight: 9
+    region: content
+    settings:
+      placeholder: ''
+      size: 60
+    third_party_settings: {  }
+  localgov_webform:
+    type: webform_entity_reference_select
+    weight: 8
+    region: content
+    settings:
+      default_data: true
+      webforms: {  }
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    weight: 3
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 6
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    weight: 4
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 1
+    region: content
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/modules/localgov_microsites_group_webform/config/install/core.entity_view_display.node.localgov_webform.default.yml
+++ b/modules/localgov_microsites_group_webform/config/install/core.entity_view_display.node.localgov_webform.default.yml
@@ -1,0 +1,42 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.localgov_webform.body
+    - field.field.node.localgov_webform.localgov_submission_confirm
+    - field.field.node.localgov_webform.localgov_submission_email
+    - field.field.node.localgov_webform.localgov_webform
+    - node.type.localgov_webform
+  module:
+    - text
+    - user
+    - webform
+id: node.localgov_webform.default
+targetEntityType: node
+bundle: localgov_webform
+mode: default
+content:
+  body:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  localgov_webform:
+    type: webform_entity_reference_entity_view
+    label: hidden
+    settings:
+      source_entity: true
+    third_party_settings: {  }
+    weight: 2
+    region: content
+hidden:
+  localgov_submission_confirm: true
+  localgov_submission_email: true
+  search_api_excerpt: true

--- a/modules/localgov_microsites_group_webform/config/install/core.entity_view_display.node.localgov_webform.teaser.yml
+++ b/modules/localgov_microsites_group_webform/config/install/core.entity_view_display.node.localgov_webform.teaser.yml
@@ -1,0 +1,36 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.localgov_webform.body
+    - field.field.node.localgov_webform.localgov_submission_confirm
+    - field.field.node.localgov_webform.localgov_submission_email
+    - field.field.node.localgov_webform.localgov_webform
+    - node.type.localgov_webform
+  module:
+    - text
+    - user
+id: node.localgov_webform.teaser
+targetEntityType: node
+bundle: localgov_webform
+mode: teaser
+content:
+  body:
+    type: text_summary_or_trimmed
+    label: hidden
+    settings:
+      trim_length: 600
+    third_party_settings: {  }
+    weight: 101
+    region: content
+  links:
+    settings: {  }
+    third_party_settings: {  }
+    weight: 100
+    region: content
+hidden:
+  localgov_submission_confirm: true
+  localgov_submission_email: true
+  localgov_webform: true
+  search_api_excerpt: true

--- a/modules/localgov_microsites_group_webform/config/install/field.field.node.localgov_webform.body.yml
+++ b/modules/localgov_microsites_group_webform/config/install/field.field.node.localgov_webform.body.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.localgov_webform
+  module:
+    - text
+id: node.localgov_webform.body
+field_name: body
+entity_type: node
+bundle: localgov_webform
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+  required_summary: false
+field_type: text_with_summary

--- a/modules/localgov_microsites_group_webform/config/install/field.field.node.localgov_webform.localgov_submission_confirm.yml
+++ b/modules/localgov_microsites_group_webform/config/install/field.field.node.localgov_webform.localgov_submission_confirm.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_submission_confirm
+    - node.type.localgov_webform
+id: node.localgov_webform.localgov_submission_confirm
+field_name: localgov_submission_confirm
+entity_type: node
+bundle: localgov_webform
+label: 'Submission confirmation'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/modules/localgov_microsites_group_webform/config/install/field.field.node.localgov_webform.localgov_submission_confirm.yml
+++ b/modules/localgov_microsites_group_webform/config/install/field.field.node.localgov_webform.localgov_submission_confirm.yml
@@ -9,8 +9,8 @@ field_name: localgov_submission_confirm
 entity_type: node
 bundle: localgov_webform
 label: 'Submission confirmation'
-description: ''
-required: false
+description: 'Please provide a confirmation message to display on successful submission.'
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/modules/localgov_microsites_group_webform/config/install/field.field.node.localgov_webform.localgov_submission_email.yml
+++ b/modules/localgov_microsites_group_webform/config/install/field.field.node.localgov_webform.localgov_submission_email.yml
@@ -9,8 +9,8 @@ field_name: localgov_submission_email
 entity_type: node
 bundle: localgov_webform
 label: 'Submission email'
-description: ''
-required: false
+description: 'Please specify the email address to which form submissions should be sent.'
+required: true
 translatable: false
 default_value: {  }
 default_value_callback: ''

--- a/modules/localgov_microsites_group_webform/config/install/field.field.node.localgov_webform.localgov_submission_email.yml
+++ b/modules/localgov_microsites_group_webform/config/install/field.field.node.localgov_webform.localgov_submission_email.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_submission_email
+    - node.type.localgov_webform
+id: node.localgov_webform.localgov_submission_email
+field_name: localgov_submission_email
+entity_type: node
+bundle: localgov_webform
+label: 'Submission email'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: email

--- a/modules/localgov_microsites_group_webform/config/install/field.field.node.localgov_webform.localgov_webform.yml
+++ b/modules/localgov_microsites_group_webform/config/install/field.field.node.localgov_webform.localgov_webform.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.localgov_webform
+    - node.type.localgov_webform
+  module:
+    - webform
+id: node.localgov_webform.localgov_webform
+field_name: localgov_webform
+entity_type: node
+bundle: localgov_webform
+label: Webform
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:webform'
+  handler_settings:
+    target_bundles: null
+    auto_create: false
+field_type: webform

--- a/modules/localgov_microsites_group_webform/config/install/field.storage.node.localgov_submission_confirm.yml
+++ b/modules/localgov_microsites_group_webform/config/install/field.storage.node.localgov_submission_confirm.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.localgov_submission_confirm
+field_name: localgov_submission_confirm
+entity_type: node
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/localgov_microsites_group_webform/config/install/field.storage.node.localgov_submission_email.yml
+++ b/modules/localgov_microsites_group_webform/config/install/field.storage.node.localgov_submission_email.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.localgov_submission_email
+field_name: localgov_submission_email
+entity_type: node
+type: email
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/localgov_microsites_group_webform/config/install/field.storage.node.localgov_webform.yml
+++ b/modules/localgov_microsites_group_webform/config/install/field.storage.node.localgov_webform.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - webform
+id: node.localgov_webform
+field_name: localgov_webform
+entity_type: node
+type: webform
+settings:
+  target_type: webform
+module: webform
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/localgov_microsites_group_webform/config/install/group.relationship_type.microsite-64024109990713ad9b0616.yml
+++ b/modules/localgov_microsites_group_webform/config/install/group.relationship_type.microsite-64024109990713ad9b0616.yml
@@ -1,0 +1,16 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.microsite
+    - node.type.localgov_webform
+  module:
+    - gnode
+    - node
+id: microsite-64024109990713ad9b0616
+group_type: microsite
+content_plugin: 'group_node:localgov_webform'
+plugin_config:
+  group_cardinality: 0
+  entity_cardinality: 1
+  use_creation_wizard: false

--- a/modules/localgov_microsites_group_webform/config/install/group.relationship_type.microsite-group_node-webform.yml
+++ b/modules/localgov_microsites_group_webform/config/install/group.relationship_type.microsite-group_node-webform.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.microsite
+    - node.type.webform
+  module:
+    - gnode
+    - node
+id: microsite-group_node-webform
+group_type: microsite
+content_plugin: 'group_node:webform'
+plugin_config:
+  group_cardinality: 0
+  entity_cardinality: 1
+  use_creation_wizard: false
+

--- a/modules/localgov_microsites_group_webform/config/install/group.relationship_type.microsite-group_node-webform.yml
+++ b/modules/localgov_microsites_group_webform/config/install/group.relationship_type.microsite-group_node-webform.yml
@@ -14,4 +14,3 @@ plugin_config:
   group_cardinality: 0
   entity_cardinality: 1
   use_creation_wizard: false
-

--- a/modules/localgov_microsites_group_webform/config/install/node.type.localgov_webform.yml
+++ b/modules/localgov_microsites_group_webform/config/install/node.type.localgov_webform.yml
@@ -1,0 +1,17 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
+name: 'Microsites webform'
+type: localgov_webform
+description: 'A simple page to which a webform can be embedded with field based overrides for target email address and other webform configuration.'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false

--- a/modules/localgov_microsites_group_webform/config/install/webform.webform.microsite_contact.yml
+++ b/modules/localgov_microsites_group_webform/config/install/webform.webform.microsite_contact.yml
@@ -58,7 +58,7 @@ settings:
   form_disable_autocomplete: false
   form_novalidate: false
   form_disable_inline_errors: false
-  form_required: false
+  form_required: true
   form_autofocus: false
   form_details_toggle: false
   form_reset: false

--- a/modules/localgov_microsites_group_webform/config/install/webform.webform.microsite_contact.yml
+++ b/modules/localgov_microsites_group_webform/config/install/webform.webform.microsite_contact.yml
@@ -1,0 +1,248 @@
+langcode: en
+status: open
+dependencies: {  }
+weight: 0
+open: null
+close: null
+uid: 1
+template: false
+archive: false
+id: microsite_contact
+title: 'Microsite contact'
+description: 'A default contact form that can be embedded in a webform node on any microsite, where important configuration can be overridden, such as target email address and confirmation message.'
+category: 'Contact forms'
+elements: |-
+  full_name:
+    '#type': textfield
+    '#title': 'Full name'
+  email_address:
+    '#type': email
+    '#title': 'Email address'
+    '#required': true
+  phone:
+    '#type': tel
+    '#title': Phone
+  message:
+    '#type': textarea
+    '#title': Message
+    '#required': true
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: both
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: false
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: inline
+  confirmation_url: ''
+  confirmation_title: ''
+  confirmation_message: '[webform_submission:node:localgov_submission_confirm:value]'
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: none
+  purge_days: null
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers:
+  email:
+    id: email
+    handler_id: email
+    label: Email
+    notes: ''
+    status: true
+    conditions: {  }
+    weight: 0
+    settings:
+      states:
+        - completed
+      to_mail: '[webform_submission:node:localgov_submission_email:value]'
+      to_options: {  }
+      bcc_mail: ''
+      bcc_options: {  }
+      cc_mail: ''
+      cc_options: {  }
+      from_mail: _default
+      from_options: {  }
+      from_name: _default
+      reply_to: ''
+      return_path: ''
+      sender_mail: ''
+      sender_name: ''
+      subject: _default
+      body: _default
+      excluded_elements: {  }
+      ignore_access: false
+      exclude_empty: true
+      exclude_empty_checkbox: false
+      exclude_attachments: false
+      html: true
+      attachments: false
+      twig: false
+      theme_name: ''
+      parameters: {  }
+      debug: false
+variants: {  }

--- a/modules/localgov_microsites_group_webform/config/install/webform.webform.microsite_contact.yml
+++ b/modules/localgov_microsites_group_webform/config/install/webform.webform.microsite_contact.yml
@@ -58,7 +58,7 @@ settings:
   form_disable_autocomplete: false
   form_novalidate: false
   form_disable_inline_errors: false
-  form_required: true
+  form_required: false
   form_autofocus: false
   form_details_toggle: false
   form_reset: false

--- a/modules/localgov_microsites_group_webform/localgov_microsites_group_webform.info.yml
+++ b/modules/localgov_microsites_group_webform/localgov_microsites_group_webform.info.yml
@@ -5,6 +5,7 @@ package: LocalGov Drupal
 core_version_requirement: ^9.3
 dependencies:
   # Drupal
+  - core:inline_form_errors
   # Contrib
   - group:group
   - group:gnode
@@ -13,3 +14,4 @@ dependencies:
   - webform_ui:webform_ui
     # LocalGov Drupal
   - group_webform:group_webform
+  - localgov_forms:localgov_forms

--- a/modules/localgov_microsites_group_webform/localgov_microsites_group_webform.info.yml
+++ b/modules/localgov_microsites_group_webform/localgov_microsites_group_webform.info.yml
@@ -1,0 +1,12 @@
+name: LocalGov Microsites Group Webform
+type: module
+description: Webform integration for Microsites.
+package: LocalGov Drupal
+core_version_requirement: ^9.3
+dependencies:
+  # Drupal
+  # Contrib
+  - group:group
+  - group:gnode
+  - webform:webform
+  # LocalGov Drupal

--- a/modules/localgov_microsites_group_webform/localgov_microsites_group_webform.info.yml
+++ b/modules/localgov_microsites_group_webform/localgov_microsites_group_webform.info.yml
@@ -9,4 +9,7 @@ dependencies:
   - group:group
   - group:gnode
   - webform:webform
-  # LocalGov Drupal
+  - webform_node:webform_node
+  - webform_ui:webform_ui
+    # LocalGov Drupal
+  - group_webform:group_webform

--- a/modules/localgov_microsites_group_webform/localgov_microsites_group_webform.install
+++ b/modules/localgov_microsites_group_webform/localgov_microsites_group_webform.install
@@ -7,35 +7,34 @@ use Drupal\Core\Cache\Cache;
  */
 function localgov_microsites_group_webform_install() {
 
-  // Add the default contact webform to the group content relationship.
+  // group.role.microsite-admin
   $config_factory = \Drupal::configFactory();
-  $config = $config_factory->getEditable('group.relationship_type.microsite-group_localgov-webform');
-  $config->set('langcode', 'en');
-  $config->set('status', 'true');
-  $dependencies = [
-    'config' => [
-      'group.type.microsite',
-      'webform.type.contact'
-    ],
-    'module' => [
-      'gnode',
-      'group_webform',
-      'webform'
-    ],
-  ];
-  $config->set('dependencies', $dependencies);
-  $config->set('id', 'microsite-group_localgov-webform');
-  $config->set('group_type', 'microsite');
-  $config->set('content_plugin', 'group_webform:localgov_webform');
-  $plugin_config = [
-    'group_cardinality' => 0,
-    'entity_cardinality' => 1,
-    'use_creation_wizard' => false,
-  ];
-  $config->set('plugin_config', $plugin_config);
-  $config->save();
-  // Need to clear the cache
-  // This does not work:
-  //Cache::invalidateTags()
+  $microsite_admin = $config_factory->getEditable('group.role.microsite-admin');
+  $permissions = $microsite_admin->get('permissions');
 
+  $permissions[] = 'create group_node:localgov_webform entity';
+  $permissions[] = 'delete any group_node:localgov_webform entity';
+  $permissions[] = 'delete own group_node:localgov_webform entity';
+  $permissions[] = 'update any group_node:localgov_webform entity';
+  $permissions[] = 'update own group_node:localgov_webform entity';
+  $permissions[] = 'view group_node:localgov_webform entity';
+
+  $permissions[] = 'create group_webform:microsite_contact entity';
+  $permissions[] = 'delete any group_webform:microsite_contact entity';
+  $permissions[] = 'delete any group_webform:microsite_contact entity';
+  $permissions[] = 'update any group_webform:microsite_contact entity';
+  $permissions[] = 'update own group_webform:microsite_contact entity';
+  $permissions[] = 'view group_webform:microsite_contact entity';
+
+  $microsite_admin->set('permissions', $permissions);
+  $microsite_admin->save();
+
+  // group.role.microsite-anonymous
+  $microsite_anon = $config_factory->getEditable('group.role.microsite-anonymous');
+  $permissions = $microsite_anon->get('permissions');
+  $permissions[] = 'view group_node:localgov_webform entity';
+  $permissions[] = 'create group_webform:microsite_contact entity';
+
+  $microsite_anon->set('permissions', $permissions);
+  $microsite_anon->save();
 }

--- a/modules/localgov_microsites_group_webform/localgov_microsites_group_webform.install
+++ b/modules/localgov_microsites_group_webform/localgov_microsites_group_webform.install
@@ -45,20 +45,48 @@ function localgov_microsites_group_webform_install() {
   $microsite_anon->set('permissions', $permissions);
   $microsite_anon->save();
 
-  // Add permission for user.role.microsites_controller to see own webform
-  // submissions.
+  // Add permission for user.role.microsites_controller to manage webforms.
   $microsites_controller = $config_factory->getEditable('user.role.microsites_controller');
   $permissions = $microsites_controller->get('permissions');
-  $permissions[] = 'view webform submissions own node';
-  $microsites_controller->set('permissions', $permissions);
+  $new_permissions = [
+    'access any webform configuration',
+    'access own webform configuration',
+    'access webform help',
+    'access webform overview',
+    'access webform submission user',
+    'administer webform',
+    'administer webform element access',
+    'administer webform submission',
+    'create webform',
+    'delete any webform',
+    'delete any webform submission',
+    'delete own webform',
+    'delete own webform submission',
+    'delete webform submissions any node',
+    'delete webform submissions own node',
+    'edit any webform',
+    'edit any webform submission',
+    'edit own webform',
+    'edit webform assets',
+    'edit webform source',
+    'edit webform submissions any node',
+    'edit webform submissions own node',
+    'edit webform twig',
+    'edit webform variants',
+    'view any webform submission',
+    'view own webform submission',
+    'view webform submissions any node',
+    'view webform submissions own node',
+  ];
+  $permissions = array_merge($permissions, $new_permissions);
+  microsites_controller->set('permissions', $permissions);
   $microsites_controller->save();
 
-  // Add permission for user.role.microsites_controller to see own webform
+  // Add permission for user.role.microsites_trusted_editor to see own webform
   // submissions.
   $microsites_trusted_editor = $config_factory->getEditable('user.role.microsites_trusted_editor');
   $permissions = $microsites_trusted_editor->get('permissions');
   $permissions[] = 'view webform submissions own node';
   $microsites_trusted_editor->set('permissions', $permissions);
   $microsites_trusted_editor->save();
-
 }

--- a/modules/localgov_microsites_group_webform/localgov_microsites_group_webform.install
+++ b/modules/localgov_microsites_group_webform/localgov_microsites_group_webform.install
@@ -1,0 +1,40 @@
+<?php
+
+use Drupal\Core\Cache\Cache;
+
+/**
+ * Implements hook_install().
+ */
+function localgov_microsites_group_webform_install() {
+
+  // Add the default contact webform to the group content relationship.
+  $config_factory = \Drupal::configFactory();
+  $config = $config_factory->getEditable('group.relationship_type.microsite-group_webform-contact');
+  $config->set('langcode', 'en');
+  $config->set('status', 'true');
+  $dependencies = [
+    'config' => [
+      'group.type.microsite',
+      'webform.type.contact'
+    ],
+    'module' => [
+      'group_webform',
+      'webform'
+    ],
+  ];
+  $config->set('dependencies', $dependencies);
+  $config->set('id', 'microsite-group_webform-contact');
+  $config->set('group_type', 'microsite');
+  $config->set('content_plugin', 'group_webform:contact');
+  $plugin_config = [
+    'group_cardinality' => 0,
+    'entity_cardinality' => 1,
+    'use_creation_wizard' => false,
+  ];
+  $config->set('plugin_config', $plugin_config);
+  $config->save();
+  // Need to clear the cache
+  // This does not work:
+  //Cache::invalidateTags()
+
+}

--- a/modules/localgov_microsites_group_webform/localgov_microsites_group_webform.install
+++ b/modules/localgov_microsites_group_webform/localgov_microsites_group_webform.install
@@ -9,7 +9,7 @@ function localgov_microsites_group_webform_install() {
 
   // Add the default contact webform to the group content relationship.
   $config_factory = \Drupal::configFactory();
-  $config = $config_factory->getEditable('group.relationship_type.microsite-group_webform-contact');
+  $config = $config_factory->getEditable('group.relationship_type.microsite-group_localgov-webform');
   $config->set('langcode', 'en');
   $config->set('status', 'true');
   $dependencies = [
@@ -18,14 +18,15 @@ function localgov_microsites_group_webform_install() {
       'webform.type.contact'
     ],
     'module' => [
+      'gnode',
       'group_webform',
       'webform'
     ],
   ];
   $config->set('dependencies', $dependencies);
-  $config->set('id', 'microsite-group_webform-contact');
+  $config->set('id', 'microsite-group_localgov-webform');
   $config->set('group_type', 'microsite');
-  $config->set('content_plugin', 'group_webform:contact');
+  $config->set('content_plugin', 'group_webform:localgov_webform');
   $plugin_config = [
     'group_cardinality' => 0,
     'entity_cardinality' => 1,

--- a/modules/localgov_microsites_group_webform/localgov_microsites_group_webform.install
+++ b/modules/localgov_microsites_group_webform/localgov_microsites_group_webform.install
@@ -7,7 +7,8 @@ use Drupal\Core\Cache\Cache;
  */
 function localgov_microsites_group_webform_install() {
 
-  // group.role.microsite-admin
+  // Add permissions for the group.role.microsite-admin to manage the
+  // localgov_webform content type and the microsite_contact submissions.
   $config_factory = \Drupal::configFactory();
   $microsite_admin = $config_factory->getEditable('group.role.microsite-admin');
   $permissions = $microsite_admin->get('permissions');
@@ -29,12 +30,32 @@ function localgov_microsites_group_webform_install() {
   $microsite_admin->set('permissions', $permissions);
   $microsite_admin->save();
 
-  // group.role.microsite-anonymous
+  // Delete the default contact webform to avoid confusion.
+  $config_factory->getEditable('webform.webform.contact')->delete();
+
+  // Add permissions for the group.role.microsite-anonymous to see the webform
+  // content type and to make submissions.
   $microsite_anon = $config_factory->getEditable('group.role.microsite-anonymous');
   $permissions = $microsite_anon->get('permissions');
   $permissions[] = 'view group_node:localgov_webform entity';
   $permissions[] = 'create group_webform:microsite_contact entity';
-
   $microsite_anon->set('permissions', $permissions);
   $microsite_anon->save();
+
+  // Add permission for user.role.microsites_controller to see own webform
+  // submissions.
+  $microsites_controller = $config_factory->getEditable('user.role.microsites_controller');
+  $permissions = $microsites_controller->get('permissions');
+  $permissions[] = 'view webform submissions own node';
+  $microsites_controller->set('permissions', $permissions);
+  $microsites_controller->save();
+
+  // Add permission for user.role.microsites_controller to see own webform
+  // submissions.
+  $microsites_trusted_editor = $config_factory->getEditable('user.role.microsites_trusted_editor');
+  $permissions = $microsites_trusted_editor->get('permissions');
+  $permissions[] = 'view webform submissions own node';
+  $microsites_trusted_editor->set('permissions', $permissions);
+  $microsites_trusted_editor->save();
+
 }

--- a/modules/localgov_microsites_group_webform/localgov_microsites_group_webform.install
+++ b/modules/localgov_microsites_group_webform/localgov_microsites_group_webform.install
@@ -1,6 +1,9 @@
 <?php
 
-use Drupal\Core\Cache\Cache;
+/**
+ * @file
+ * LocalGov Microsites Group Webfor module install file.
+ */
 
 /**
  * Implements hook_install().

--- a/modules/localgov_microsites_group_webform/localgov_microsites_group_webform.install
+++ b/modules/localgov_microsites_group_webform/localgov_microsites_group_webform.install
@@ -79,7 +79,7 @@ function localgov_microsites_group_webform_install() {
     'view webform submissions own node',
   ];
   $permissions = array_merge($permissions, $new_permissions);
-  microsites_controller->set('permissions', $permissions);
+  $microsites_controller->set('permissions', $permissions);
   $microsites_controller->save();
 
   // Add permission for user.role.microsites_trusted_editor to see own webform

--- a/modules/localgov_microsites_group_webform/localgov_microsites_group_webform.install
+++ b/modules/localgov_microsites_group_webform/localgov_microsites_group_webform.install
@@ -21,7 +21,7 @@ function localgov_microsites_group_webform_install() {
 
   $permissions[] = 'create group_webform:microsite_contact entity';
   $permissions[] = 'delete any group_webform:microsite_contact entity';
-  $permissions[] = 'delete any group_webform:microsite_contact entity';
+  $permissions[] = 'delete own group_webform:microsite_contact entity';
   $permissions[] = 'update any group_webform:microsite_contact entity';
   $permissions[] = 'update own group_webform:microsite_contact entity';
   $permissions[] = 'view group_webform:microsite_contact entity';

--- a/modules/localgov_microsites_group_webform/localgov_microsites_group_webform.module
+++ b/modules/localgov_microsites_group_webform/localgov_microsites_group_webform.module
@@ -1,4 +1,10 @@
 <?php
+
+/**
+ * @file
+ * LocalGov Microsites Group Webform module file.
+ */
+
 use Drupal\group\Entity\Group;
 use Drupal\group\Entity\Storage\GroupRelationshipTypeStorageInterface;
 
@@ -28,7 +34,7 @@ function localgov_microsites_group_webform_entity_insert($entity) {
     $plugin_id = 'group_webform:' . $webform_id;
 
     // Now we get the group_type config entity, which we need to pass to
-    // the GroupRelationshipTypeStorageInterface -> createFromPlugin
+    // the GroupRelationshipTypeStorageInterface -> createFromPlugin.
     $group_type_storage = \Drupal::entityTypeManager()->getStorage('group_type');
     $group_type = $group_type_storage->load('microsite');
 
@@ -36,7 +42,7 @@ function localgov_microsites_group_webform_entity_insert($entity) {
     // https://git.drupalcode.org/project/group/-/blob/3.0.x/src/Entity/Form/GroupRelationshipTypeForm.php#L145-147
     $storage = \Drupal::entityTypeManager()->getStorage('group_relationship_type');
     assert($storage instanceof GroupRelationshipTypeStorageInterface);
-    $storage->createFromPlugin($group_type, $plugin_id )->save();
+    $storage->createFromPlugin($group_type, $plugin_id)->save();
 
   }
 
@@ -48,7 +54,7 @@ function localgov_microsites_group_webform_entity_insert($entity) {
     $group_id = \Drupal::service('domain_group_resolver')->getActiveDomainGroupId();
 
     // If we can't find it with the domain_group_resolver, try with the url.
-    // @TODO - check if this is actually necessary.
+    // @todo check if this is actually necessary.
     if (is_null($group_id)) {
       $group = \Drupal::request()->attributes->get('group');
       if ($group) {
@@ -66,11 +72,12 @@ function localgov_microsites_group_webform_entity_insert($entity) {
       $webform = $entity->getWebform();
       $webform_id = $webform->id();
 
-      // The plugin is in the form 'group_webform:contact' for 'contact' webform.
+      // The plugin is in the form 'group_webform:contact' for the 'contact'
+      // webform.
       $plugin_id = "group_webform:" . $webform_id;
 
       // Add the webform submission to the group.
-      $relationship = $group->addRelationship($entity, $plugin_id);
+      $group->addRelationship($entity, $plugin_id);
 
     }
   }

--- a/modules/localgov_microsites_group_webform/localgov_microsites_group_webform.module
+++ b/modules/localgov_microsites_group_webform/localgov_microsites_group_webform.module
@@ -1,15 +1,6 @@
 <?php
-// use Drupal\Core\Form\FormStateInterface;
-// use DrupalCore\Config\ConfigFactory;
 use Drupal\group\Entity\Group;
-// use Drupal\group\Entity\GroupRelationshipInterface;
-// use Drupal\group\Entity\GroupInterface;
-// use Drupal\group\Entity\GroupType;
-// use Drupal\group\Entity\GroupTypeInterface;
-// use Drupal\group\Entity\GroupRelationshipTypeInterface;
-// use Drupal\group\Entity\GroupRelationshipType;
 use Drupal\group\Entity\Storage\GroupRelationshipTypeStorageInterface;
-
 
 /**
  * Implements hook_entity_update().

--- a/modules/localgov_microsites_group_webform/localgov_microsites_group_webform.module
+++ b/modules/localgov_microsites_group_webform/localgov_microsites_group_webform.module
@@ -1,0 +1,86 @@
+<?php
+// use Drupal\Core\Form\FormStateInterface;
+// use DrupalCore\Config\ConfigFactory;
+use Drupal\group\Entity\Group;
+// use Drupal\group\Entity\GroupRelationshipInterface;
+// use Drupal\group\Entity\GroupInterface;
+// use Drupal\group\Entity\GroupType;
+// use Drupal\group\Entity\GroupTypeInterface;
+// use Drupal\group\Entity\GroupRelationshipTypeInterface;
+// use Drupal\group\Entity\GroupRelationshipType;
+use Drupal\group\Entity\Storage\GroupRelationshipTypeStorageInterface;
+
+
+/**
+ * Implements hook_entity_update().
+ */
+function localgov_microsites_group_webform_entity_update($entity) {
+  // We might need to do something in hook_entity_update() too.
+}
+
+/**
+ * Implements hook_entity_insert().
+ */
+function localgov_microsites_group_webform_entity_insert($entity) {
+
+  // Check for entity type, we only want to act on webform / webform_submission.
+  $entity_type = $entity->getEntityTypeId();
+
+  // For the webform, every time a webform is created, we want to add it to the
+  // microsite group type, to make sure a submission can be assigned to a
+  // group.
+  if ($entity_type == 'webform') {
+
+    // The format of the plugin_id is llike group_webform:contact, the latter
+    // being the webform id.
+    $webform_id = $entity->id();
+    $plugin_id = 'group_webform:' . $webform_id;
+
+    // Now we get the group_type config entity, which we need to pass to
+    // the GroupRelationshipTypeStorageInterface -> createFromPlugin
+    $group_type_storage = \Drupal::entityTypeManager()->getStorage('group_type');
+    $group_type = $group_type_storage->load('microsite');
+
+    // Got this from lines 145-147 of GroupRelationshipTypeForm.php
+    // https://git.drupalcode.org/project/group/-/blob/3.0.x/src/Entity/Form/GroupRelationshipTypeForm.php#L145-147
+    $storage = \Drupal::entityTypeManager()->getStorage('group_relationship_type');
+    assert($storage instanceof GroupRelationshipTypeStorageInterface);
+    $storage->createFromPlugin($group_type, $plugin_id )->save();
+
+  }
+
+  // For the webform_submission, we just need to hook into the submission and
+  // add it to the group with $group->addRelationship.
+  if ($entity_type == 'webform_submission') {
+
+    // Find the active group.
+    $group_id = \Drupal::service('domain_group_resolver')->getActiveDomainGroupId();
+
+    // If we can't find it with the domain_group_resolver, try with the url.
+    // @TODO - check if this is actually necessary.
+    if (is_null($group_id)) {
+      $group = \Drupal::request()->attributes->get('group');
+      if ($group) {
+        $group_id = $group->id();
+      }
+    }
+
+    // If we have a $group_id, let's load it and add a new group relationsship.
+    if ($group_id) {
+
+      // Load the group.
+      $group = Group::load($group_id);
+
+      // Get the webform and then webform_id to generate the expected plugin_id.
+      $webform = $entity->getWebform();
+      $webform_id = $webform->id();
+
+      // The plugin is in the form 'group_webform:contact' for 'contact' webform.
+      $plugin_id = "group_webform:" . $webform_id;
+
+      // Add the webform submission to the group.
+      $relationship = $group->addRelationship($entity, $plugin_id);
+
+    }
+  }
+}


### PR DESCRIPTION
This should be ready to test!

Steps to test.

Fresh install, enable localgov_microsites_group_webform

`lando drush si localgov_microsites -y; lando drush en localgov_microsites_group_webform -y ; lando drush cr; lando drush uli; 
`

Then: 

1. Create a controller user, log in as controller
2. Create microsite 1 and microsite 2
3. Create 2 trusted editor users and assign to each microsite as a microsite admin
4. Log into microsite 1 as admin 1
5. On site 1 as admin 1, create a microsite webform node, with overrides for submission email and confirmation message.
6. On site 2 as admin 2, create a microsite webform node, with overrides for submission email and confirmation message.
7. As anonymous, create submissions on each webform
8. As admin 1 on site 1 confirm I can see the submissions for my site and not see the submissions for other sites
9. As admin 2 on site 2, confirm I can see the submissions for my site and not see the submissions for other sites.


