### PR TITLE
Update: group_content_menu module version reference

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "drupal/field_formatter_class": "^1.5",
     "drupal/ginvite": "4.0.0-alpha1",
     "drupal/group": "^3.0.0-beta4",
-    "drupal/group_content_menu": "3.x-dev#9bb967ba",
+    "drupal/group_content_menu": "3.0.x-dev#04623d14",
     "drupal/group_permissions": "2.0.x-dev#0b0aef57",
     "drupal/group_term": "4.0.0-alpha2",
     "drupal/groupmedia": "4.0.0-alpha1 ",

--- a/tests/src/Functional/MicrositeCreationTest.php
+++ b/tests/src/Functional/MicrositeCreationTest.php
@@ -9,6 +9,9 @@ use Drupal\Tests\BrowserTestBase;
 /**
  * Tests the creation of microsites.
  *
+ * Note: For this test to pass, Drupal should be able to resolve the
+ * group-a1.localhost domain.  Site also needs to run on the standard HTTP port.
+ *
  * @group localgov_microsites_group
  */
 class MicrositeCreationTest extends BrowserTestBase {


### PR DESCRIPTION
Updating dependency declaration on the group_content_menu module.  This has become necessary as the group_content_menu module has replaced its 3.x branch with the [3.0.x branch](https://git.drupalcode.org/project/group_content_menu/-/tree/3.0.x).

There is a [related change](https://github.com/localgovdrupal/localgov_microsites_project/pull/18/) in localgov_microsites_project repo.  For the automated tests to pass, both these pull requests should be tested together.