### PR TITLE
Feature: Controller site indicator

### DIFF
--- a/css/control-site-toolbar.css
+++ b/css/control-site-toolbar.css
@@ -1,0 +1,14 @@
+/**
+ * @file
+ * Style rule overrides for the admin toolbar.
+ */
+
+/**
+ * Toolbar background override.
+ *
+ * Blue background for toolbar.  With accessiblity in mind.
+ * @see https://davidmathlogic.com/colorblind/
+ */
+.toolbar .toolbar-bar {
+  background-color: #1E88E5;
+}

--- a/css/toolbar-icons.css
+++ b/css/toolbar-icons.css
@@ -1,0 +1,13 @@
+/**
+ * @file
+ * Toolbar icons.
+ */
+
+/**
+ * Warning icon for toolbar items.
+ *
+ * @see core/misc/icons/e29700/warning.svg
+ */
+.toolbar-bar .toolbar-icon-warning::before {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='%23e29700'%3E%3Cpath d='M14.66 12.316l-5.316-10.633c-.738-1.476-1.946-1.476-2.685 0l-5.317 10.633c-.738 1.477.008 2.684 1.658 2.684h10.002c1.65 0 2.396-1.207 1.658-2.684zm-7.66-8.316h2.002v5h-2.002v-5zm2.252 8.615c0 .344-.281.625-.625.625h-1.25c-.345 0-.626-.281-.626-.625v-1.239c0-.344.281-.625.626-.625h1.25c.344 0 .625.281.625.625v1.239z'/%3E%3C/svg%3E");
+}

--- a/localgov_microsites_group.libraries.yml
+++ b/localgov_microsites_group.libraries.yml
@@ -1,0 +1,12 @@
+# Control site indicator.
+control_site_toolbar_override:
+  version: VERSION
+  css:
+    theme:
+      css/control-site-toolbar.css: {}
+
+toolbar_icons:
+  version: VERSION
+  css:
+    theme:
+      css/toolbar-icons.css: {}

--- a/localgov_microsites_group.module
+++ b/localgov_microsites_group.module
@@ -425,3 +425,41 @@ function localgov_microsites_group_views_query_substitutions(ViewExecutable $vie
     ];
   }
 }
+
+/**
+ * Implements hook_toolbar().
+ *
+ * - Adds a Control site indicator to the toolbar.
+ */
+function localgov_microsites_group_toolbar() {
+
+  if (!Drupal::hasService('domain.negotiator')) {
+    return;
+  }
+
+  $active_domain = Drupal::service('domain.negotiator')->getActiveDomain();
+  if (empty($active_domain) || !$active_domain->get('is_default')) {
+    return;
+  }
+
+  return [
+    'localgov-microsites-group-toolbar-override' => [
+      '#attached' => [
+        'library' => 'localgov_microsites_group/control_site_toolbar_override',
+      ],
+    ],
+    'localgov-microsites-group-control-site-indicator' => [
+      '#type' => 'toolbar_item',
+      '#weight' => 101,
+      'tab'   => [
+        '#type' => 'html_tag',
+        '#tag'  => 'div',
+        '#value' => t("Control site: Don't edit content"),
+        '#attributes' => ['class' => ['toolbar-icon', 'toolbar-icon-warning']],
+        '#attached' => [
+          'library' => 'localgov_microsites_group/toolbar_icons',
+        ],
+      ],
+    ],
+  ];
+}


### PR DESCRIPTION
A short warning message for the admin toolbar.  Appears on control sites only. Warns against editing content.

Closes https://github.com/localgovdrupal/localgov_microsites/issues/372