### PR TITLE
Fix access to the microsites overview view

### DIFF
--- a/localgov_microsites_group.install
+++ b/localgov_microsites_group.install
@@ -90,3 +90,36 @@ function localgov_microsites_group_update_9002(&$sandbox) {
     $my_invitations_view->save();
   }
 }
+
+/**
+ * Fix access to the microsites overview view.
+ */
+function localgov_microsites_group_update_9003() {
+  $permission = 'access microsites overview';
+
+  // Add 'access microsites overview' permission to microsites controller role.
+  /** @var \Drupal\user\Entity\Role $controller_role */
+  $controller_role = \Drupal::entityTypeManager()
+    ->getStorage('user_role')
+    ->load('microsites_controller');
+  if (!$controller_role->hasPermission($permission)) {
+    $controller_role->grantPermission($permission);
+    $controller_role->save();
+  }
+
+  // Update access to the microsites overview view.
+  $microsites_view = \Drupal::entityTypeManager()
+    ->getStorage('view')
+    ->load('localgov_microsites_overview');
+  $displays = $microsites_view->get('display');
+  if (
+    isset($displays['default']['display_options']['access']['type']) &&
+    $displays['default']['display_options']['access']['type'] === 'perm' &&
+    isset($displays['default']['display_options']['access']['options']['perm']) &&
+    $displays['default']['display_options']['access']['options']['perm'] == 'bypass group access'
+  ) {
+    $displays['default']['display_options']['access']['options']['perm'] = $permission;
+    $microsites_view->set('display', $displays);
+    $microsites_view->save();
+  }
+}

--- a/localgov_microsites_group.permissions.yml
+++ b/localgov_microsites_group.permissions.yml
@@ -1,2 +1,2 @@
 access microsites overview:
-  title: 'Access the Microcistes overview page'
+  title: 'Access the Microsites overview page'


### PR DESCRIPTION
The 'bypass group access' permission was removed before the upgrade to 3.x and disappears entirely in the 3.x branch. Access to the microsites overview view is broken when upgrading until access in the view is fixed. This MR will help anyone upgrading as it will fix the view access settings.

There's a PR to add an identical upgrade hook to the 2.x branch.


Part of #416 