### PR TITLE
Simplify getting the group from context.

### DIFF
--- a/localgov_microsites_group.module
+++ b/localgov_microsites_group.module
@@ -141,17 +141,14 @@ function localgov_microsites_group_entity_extra_field_info() {
 function localgov_microsites_group_menu_link_content_presave(MenuLinkContentInterface $entity) {
 
   // Find active group.
-  $group_id = localgov_microsites_group_get_group_id();
-  if (is_null($group_id)) {
+  $group = localgov_microsites_get_group_by_context();
+  if (is_null($group)) {
     $group = \Drupal::request()->attributes->get('group');
-    if ($group) {
-      $group_id = $group->id();
-    }
   }
 
   // Clear group cache so menu links are visible.
-  if ($group_id) {
-    Cache::invalidateTags(['group:' . $group_id]);
+  if ($group) {
+    Cache::invalidateTags(['group:' . $group->id()]);
   }
 }
 
@@ -288,9 +285,9 @@ function localgov_microsites_group_user_login_form_submit($form, FormStateInterf
     $form_state->setRedirect('system.admin');
   }
   // Login to a domain group.
-  $group_id = localgov_microsites_group_get_group_id();
-  if ($group_id) {
-    $form_state->setRedirect('entity.group.canonical', ['group' => $group_id]);
+  $group = localgov_microsites_get_group_by_context();
+  if ($group) {
+    $form_state->setRedirect('entity.group.canonical', ['group' => $group->id()]);
   }
 }
 
@@ -298,11 +295,10 @@ function localgov_microsites_group_user_login_form_submit($form, FormStateInterf
  * Additional submit handler to associate media with group when in domain group.
  */
 function localgov_microsites_group_media_library_add_form_submit($form, FormStateInterface $form_state) {
-  if (($group_id = localgov_microsites_group_get_group_id()) &&
+  if (($group = localgov_microsites_get_group_by_context()) &&
     ($added_media = $form_state->get('media'))
   ) {
-    $groups[] = Group::load($group_id);
-    \Drupal::service('groupmedia.attach_group')->assignMediaToGroups($added_media, $groups);
+    \Drupal::service('groupmedia.attach_group')->assignMediaToGroups($added_media, [$group]);
   }
 }
 
@@ -484,9 +480,11 @@ function localgov_microsites_group_localgov_microsites_roles_default() {
 }
 
 /**
- * Get the current group id from the domain context.
+ * Get current group from the domain context.
+ *
+ * https://www.drupal.org/project/group_sites/issues/3437912
  */
-function localgov_microsites_group_get_group_id() {
+function localgov_microsites_get_group_by_context(): ?GroupInterface {
 
   $context_id = \Drupal::service('config.factory')->get('group_sites.settings')->get('context_provider');
   if ($context_id === NULL) {
@@ -501,6 +499,8 @@ function localgov_microsites_group_get_group_id() {
     if (!$group instanceof GroupInterface) {
       throw new \InvalidArgumentException('Context value is not a Group entity.');
     }
-    return $group->id();
+    return $group;
   }
+
+  return NULL;
 }

--- a/localgov_microsites_group.module
+++ b/localgov_microsites_group.module
@@ -13,7 +13,6 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
 use Drupal\Core\StringTranslation\TranslatableMarkup;
 use Drupal\Core\Url;
-use Drupal\group\Entity\Group;
 use Drupal\group\Entity\GroupInterface;
 use Drupal\group\Entity\GroupRelationshipInterface;
 use Drupal\localgov_microsites_group\DomainSettingsHelper;
@@ -141,7 +140,7 @@ function localgov_microsites_group_entity_extra_field_info() {
 function localgov_microsites_group_menu_link_content_presave(MenuLinkContentInterface $entity) {
 
   // Find active group.
-  $group = localgov_microsites_get_group_by_context();
+  $group = localgov_microsites_group_get_by_context();
   if (is_null($group)) {
     $group = \Drupal::request()->attributes->get('group');
   }
@@ -285,7 +284,7 @@ function localgov_microsites_group_user_login_form_submit($form, FormStateInterf
     $form_state->setRedirect('system.admin');
   }
   // Login to a domain group.
-  $group = localgov_microsites_get_group_by_context();
+  $group = localgov_microsites_group_get_by_context();
   if ($group) {
     $form_state->setRedirect('entity.group.canonical', ['group' => $group->id()]);
   }
@@ -295,7 +294,7 @@ function localgov_microsites_group_user_login_form_submit($form, FormStateInterf
  * Additional submit handler to associate media with group when in domain group.
  */
 function localgov_microsites_group_media_library_add_form_submit($form, FormStateInterface $form_state) {
-  if (($group = localgov_microsites_get_group_by_context()) &&
+  if (($group = localgov_microsites_group_get_by_context()) &&
     ($added_media = $form_state->get('media'))
   ) {
     \Drupal::service('groupmedia.attach_group')->assignMediaToGroups($added_media, [$group]);
@@ -482,9 +481,12 @@ function localgov_microsites_group_localgov_microsites_roles_default() {
 /**
  * Get current group from the domain context.
  *
- * https://www.drupal.org/project/group_sites/issues/3437912
+ * @see https://www.drupal.org/project/group_sites/issues/3437912
+ *
+ * @return \Drupal\group\Entity\GroupInterface|null
+ *   The group from group_site context if there is one.
  */
-function localgov_microsites_get_group_by_context(): ?GroupInterface {
+function localgov_microsites_group_get_by_context(): ?GroupInterface {
 
   $context_id = \Drupal::service('config.factory')->get('group_sites.settings')->get('context_provider');
   if ($context_id === NULL) {

--- a/modules/localgov_microsites_group_term_ui/localgov_microsites_group_term_ui.module
+++ b/modules/localgov_microsites_group_term_ui/localgov_microsites_group_term_ui.module
@@ -75,7 +75,7 @@ function localgov_microsites_group_term_ui_form_alter(&$form, FormStateInterface
   if (isset($form['relations']['parent']['#options'])) {
 
     // Find group.
-    $group = localgov_microsites_get_group_by_context();
+    $group = localgov_microsites_group_get_by_context();
     if (is_null($group)) {
       /** @var \Drupal\group\Entity\Group $group */
       $group = \Drupal::routeMatch()->getParameter('group');

--- a/modules/localgov_microsites_group_term_ui/localgov_microsites_group_term_ui.module
+++ b/modules/localgov_microsites_group_term_ui/localgov_microsites_group_term_ui.module
@@ -75,11 +75,8 @@ function localgov_microsites_group_term_ui_form_alter(&$form, FormStateInterface
   if (isset($form['relations']['parent']['#options'])) {
 
     // Find group.
-    $group_id = localgov_microsites_group_get_group_id();
-    if (!is_null($group_id)) {
-      $group = \Drupal::entityTypeManager()->getStorage('group')->load($group_id);
-    }
-    else {
+    $group = localgov_microsites_get_group_by_context();
+    if (is_null($group)) {
       /** @var \Drupal\group\Entity\Group $group */
       $group = \Drupal::routeMatch()->getParameter('group');
     }


### PR DESCRIPTION
Rather than getting id and reloading group often.

Just as I was starting to use the method for something else. Thought I'd directly simplify this.

As yet untested. I've just written the code. So needs tests to run, and another set of eyes on it.