### PR TITLE
Rationalise tests to use group ids 1, 2, 3, 4, 5 and add test for admin access

### DIFF
--- a/modules/localgov_microsites_directories/tests/src/Functional/MicrositeDirectoryContentTest.php
+++ b/modules/localgov_microsites_directories/tests/src/Functional/MicrositeDirectoryContentTest.php
@@ -62,14 +62,14 @@ class MicrositeDirectoryContentTest extends BrowserTestBase {
 
     $this->createMicrositeGroups([], 2);
     $this->createMicrositeGroupsDomains($this->groups);
-    $this->domain1 = $this->getDomainFromGroup($this->groups[0]);
-    $this->domain2 = $this->getDomainFromGroup($this->groups[1]);
+    $this->domain1 = $this->getDomainFromGroup($this->groups[1]);
+    $this->domain2 = $this->getDomainFromGroup($this->groups[2]);
 
     // Create some directory content.
-    $this->channel1 = $this->createDirectoryChannel($this->groups[0]);
-    $this->pages1 = $this->createDirectoryPages($this->channel1, $this->groups[0], 2);
-    $this->channel2 = $this->createDirectoryChannel($this->groups[1]);
-    $this->pages2 = $this->createDirectoryPages($this->channel2, $this->groups[1], 2);
+    $this->channel1 = $this->createDirectoryChannel($this->groups[1]);
+    $this->pages1 = $this->createDirectoryPages($this->channel1, $this->groups[1], 2);
+    $this->channel2 = $this->createDirectoryChannel($this->groups[2]);
+    $this->pages2 = $this->createDirectoryPages($this->channel2, $this->groups[2], 2);
 
     // Index directory content.
     $index = Index::load('localgov_directories_index_default');

--- a/modules/localgov_microsites_directories/tests/src/Functional/MicrositeDirectoryFacetTest.php
+++ b/modules/localgov_microsites_directories/tests/src/Functional/MicrositeDirectoryFacetTest.php
@@ -60,13 +60,13 @@ class MicrositeDirectoryFacetTest extends BrowserTestBase {
 
     $this->createMicrositeGroups([], 2);
     $this->createMicrositeGroupsDomains($this->groups);
-    $this->domain1 = $this->getDomainFromGroup($this->groups[0]);
-    $this->domain2 = $this->getDomainFromGroup($this->groups[1]);
+    $this->domain1 = $this->getDomainFromGroup($this->groups[1]);
+    $this->domain2 = $this->getDomainFromGroup($this->groups[2]);
 
     // Create a user.
     $this->user = $this->drupalCreateUser();
-    $this->groups[0]->addMember($this->user, ['group_roles' => ['microsite-admin']]);
     $this->groups[1]->addMember($this->user, ['group_roles' => ['microsite-admin']]);
+    $this->groups[2]->addMember($this->user, ['group_roles' => ['microsite-admin']]);
   }
 
   /**
@@ -87,14 +87,14 @@ class MicrositeDirectoryFacetTest extends BrowserTestBase {
     // Create facet type.
     $type_listing_url = Url::fromRoute('entity.group_relationship.group_localgov_directories_facet_type.list',
       [
-        'group' => $this->groups[0]->id(),
+        'group' => $this->groups[1]->id(),
       ],
     )->toString();
     $this->drupalGet($this->domain1->getUrl() . $type_listing_url);
     $this->assertSession()->pageTextNotContains($facet_type);
     $type_add_url = Url::fromRoute('entity.group_relationship.group_localgov_directories_facet_type.add',
       [
-        'group' => $this->groups[0]->id(),
+        'group' => $this->groups[1]->id(),
       ],
     )->toString();
     $this->drupalGet($this->domain1->getUrl() . $type_add_url);
@@ -108,7 +108,7 @@ class MicrositeDirectoryFacetTest extends BrowserTestBase {
     // Create facet.
     $facet_listing_url = Url::fromRoute('view.lgms_group_directory_facets.page',
       [
-        'group' => $this->groups[0]->id(),
+        'group' => $this->groups[1]->id(),
         'localgov_directories_facets_type' => $facet_type_id,
       ],
     )->toString();
@@ -116,7 +116,7 @@ class MicrositeDirectoryFacetTest extends BrowserTestBase {
     $this->assertSession()->pageTextContains('There are no directory facets yet.');
     $facet_add_url = Url::fromRoute('entity.group_relationship.group_localgov_directories_facets.add',
       [
-        'group' => $this->groups[0]->id(),
+        'group' => $this->groups[1]->id(),
         'localgov_directories_facets_type' => $facet_type_id,
       ],
     )->toString();
@@ -137,7 +137,7 @@ class MicrositeDirectoryFacetTest extends BrowserTestBase {
     // Check facet type is listed.
     $type_listing_url = Url::fromRoute('entity.group_relationship.group_localgov_directories_facet_type.list',
       [
-        'group' => $this->groups[1]->id(),
+        'group' => $this->groups[2]->id(),
       ],
     )->toString();
     $this->drupalGet($this->domain2->getUrl() . $type_listing_url);
@@ -146,7 +146,7 @@ class MicrositeDirectoryFacetTest extends BrowserTestBase {
     // Check facet isn't listed.
     $facet_listing_url = Url::fromRoute('view.lgms_group_directory_facets.page',
       [
-        'group' => $this->groups[1]->id(),
+        'group' => $this->groups[2]->id(),
         'localgov_directories_facets_type' => $facet_type_id,
       ],
     )->toString();

--- a/modules/localgov_microsites_events/tests/src/Functional/MicrositeEventContentTest.php
+++ b/modules/localgov_microsites_events/tests/src/Functional/MicrositeEventContentTest.php
@@ -62,12 +62,12 @@ class MicrositeEventContentTest extends BrowserTestBase {
 
     $this->createMicrositeGroups([], 2);
     $this->createMicrositeGroupsDomains($this->groups);
-    $this->domain1 = $this->getDomainFromGroup($this->groups[0]);
-    $this->domain2 = $this->getDomainFromGroup($this->groups[1]);
+    $this->domain1 = $this->getDomainFromGroup($this->groups[1]);
+    $this->domain2 = $this->getDomainFromGroup($this->groups[2]);
 
     // Create some content.
-    $this->pages1 = $this->createEvents($this->groups[0], 2);
-    $this->pages2 = $this->createEvents($this->groups[1], 2);
+    $this->pages1 = $this->createEvents($this->groups[1], 2);
+    $this->pages2 = $this->createEvents($this->groups[2], 2);
 
     // Index events.
     $index = Index::load('localgov_events');

--- a/modules/localgov_microsites_news/tests/src/Functional/MicrositeNewsContentTest.php
+++ b/modules/localgov_microsites_news/tests/src/Functional/MicrositeNewsContentTest.php
@@ -61,14 +61,14 @@ class MicrositeNewsContentTest extends BrowserTestBase {
 
     $this->createMicrositeGroups([], 2);
     $this->createMicrositeGroupsDomains($this->groups);
-    $this->domain1 = $this->getDomainFromGroup($this->groups[0]);
-    $this->domain2 = $this->getDomainFromGroup($this->groups[1]);
+    $this->domain1 = $this->getDomainFromGroup($this->groups[1]);
+    $this->domain2 = $this->getDomainFromGroup($this->groups[2]);
 
     // Create some directory content.
-    $this->newsroom1 = $this->createNewsroom($this->groups[0]);
-    $this->article1 = $this->createNewsArticles($this->newsroom1, $this->groups[0], 2);
-    $this->newsroom2 = $this->createNewsroom($this->groups[1]);
-    $this->article2 = $this->createNewsArticles($this->newsroom2, $this->groups[1], 2);
+    $this->newsroom1 = $this->createNewsroom($this->groups[1]);
+    $this->article1 = $this->createNewsArticles($this->newsroom1, $this->groups[1], 2);
+    $this->newsroom2 = $this->createNewsroom($this->groups[2]);
+    $this->article2 = $this->createNewsArticles($this->newsroom2, $this->groups[2], 2);
 
     // Index directory content.
     $index = Index::load('localgov_news');

--- a/tests/src/Functional/GroupAdminAccessTest.php
+++ b/tests/src/Functional/GroupAdminAccessTest.php
@@ -104,20 +104,41 @@ class GroupAdminAccessTest extends BrowserTestBase {
       'pass' => $this->adminUser1->passRaw,
     ], 'Log in');
 
-    // Confirm that adminUser1 can manage nodes on group2.
+    // Confirm that adminUser1 can manage content and entities on group2.
+    $this->drupalGet($group1_domain->getUrl() . '/group/' . $group1->id());
+    $this->assertSession()->statusCodeEquals(200);
+    $this->drupalGet($group1_domain->getUrl() . '/group/' . $group1->id() . '/edit');
+    $this->assertSession()->statusCodeEquals(200);
     $this->drupalGet($group1_domain->getUrl() . '/group/' . $group1->id() . '/nodes');
     $this->assertSession()->statusCodeEquals(200);
+    $this->drupalGet($group1_domain->getUrl() . '/group/' . $group1->id() . '/domain-settings');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->drupalGet($group1_domain->getUrl() . '/group/' . $group1->id() . '/menus');
+    $this->assertSession()->statusCodeEquals(200);
+    $this->drupalGet($group1_domain->getUrl() . '/group/' . $group1->id() . '/members');
+    $this->assertSession()->statusCodeEquals(200);
 
-    // First login to group2 domain.
+    // First login to group2 domain as adminUser1.
     $this->drupalGet($group2_domain->getUrl() . Url::fromRoute('user.login')->toString());
     $this->submitForm([
       'name' => $this->adminUser1->getAccountName(),
       'pass' => $this->adminUser1->passRaw,
     ], 'Log in');
 
-    // Now confirm that adminUser1 cannot manage nodes on group2.
+    // Now confirm that adminUser1 cannot manage content and settings on group2.
+    $this->drupalGet($group2_domain->getUrl() . '/group/' . $group2->id());
+    $this->assertSession()->statusCodeEquals(403);
+    $this->drupalGet($group2_domain->getUrl() . '/group/' . $group2->id() . '/edit');
+    $this->assertSession()->statusCodeEquals(403);
     $this->drupalGet($group2_domain->getUrl() . '/group/' . $group2->id() . '/nodes');
     $this->assertSession()->statusCodeEquals(403);
+    $this->drupalGet($group2_domain->getUrl() . '/group/' . $group2->id() . '/domain-settings');
+    $this->assertSession()->statusCodeEquals(403);
+    $this->drupalGet($group2_domain->getUrl() . '/group/' . $group2->id() . '/menus');
+    $this->assertSession()->statusCodeEquals(403);
+    $this->drupalGet($group2_domain->getUrl() . '/group/' . $group2->id() . '/members');
+    $this->assertSession()->statusCodeEquals(403);
+    $this->drupalGet($group2_domain->getUrl() . '/group/' . $group2->id() . '/nodes');
 
   }
 

--- a/tests/src/Functional/GroupAdminAccessTest.php
+++ b/tests/src/Functional/GroupAdminAccessTest.php
@@ -7,8 +7,8 @@ use Drupal\Core\Url;
 use Drupal\domain\DomainInterface;
 use Drupal\localgov_microsites_group\DomainFromGroupTrait;
 use Drupal\Tests\BrowserTestBase;
-use Drupal\Tests\localgov_microsites_group\Traits\InitializeGroupsTrait;
 use Drupal\Tests\localgov_microsites_group\Traits\GroupCreationTrait;
+use Drupal\Tests\localgov_microsites_group\Traits\InitializeGroupsTrait;
 use Drupal\Tests\user\Traits\UserCreationTrait;
 
 /**
@@ -95,7 +95,7 @@ class GroupAdminAccessTest extends BrowserTestBase {
     $group2 = $this->groups[2];
 
     // Admin1 can access content on site 1.
-    $group1_domain = $this->getDomainFromGroup($group1 );
+    $group1_domain = $this->getDomainFromGroup($group1);
     $group2_domain = $this->getDomainFromGroup($group2);
     assert($group1_domain instanceof DomainInterface);
     $this->drupalGet($group1_domain->getUrl() . Url::fromRoute('user.login')->toString());

--- a/tests/src/Functional/GroupAdminAccessTest.php
+++ b/tests/src/Functional/GroupAdminAccessTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Drupal\Tests\localgov_microsites_group\Functional;
+
+use Drupal\Core\Test\AssertMailTrait;
+use Drupal\Core\Url;
+use Drupal\domain\DomainInterface;
+use Drupal\localgov_microsites_group\DomainFromGroupTrait;
+use Drupal\Tests\BrowserTestBase;
+use Drupal\Tests\localgov_microsites_group\Traits\InitializeGroupsTrait;
+use Drupal\Tests\localgov_microsites_group\Traits\GroupCreationTrait;
+use Drupal\Tests\user\Traits\UserCreationTrait;
+
+/**
+ * Tests the group and group content access.
+ *
+ * @group localgov_microsites_group
+ */
+class GroupAdminAccessTest extends BrowserTestBase {
+
+  use UserCreationTrait;
+  use InitializeGroupsTrait;
+  use AssertMailTrait;
+  use GroupCreationTrait, DomainFromGroupTrait {
+    GroupCreationTrait::getEntityTypeManager insteadof DomainFromGroupTrait;
+  }
+  /**
+   * Will be removed when issue #3204455 on Domain Site Settings gets merged.
+   *
+   * See https://www.drupal.org/project/domain_site_settings/issues/3204455.
+   *
+   * @var bool
+   * @see \Drupal\Core\Config\Development\ConfigSchemaChecker
+   * phpcs:disable DrupalPractice.Objects.StrictSchemaDisabled.StrictConfigSchema
+   */
+  protected $strictConfigSchema = FALSE;
+
+  /**
+   * Modules to enable.
+   *
+   * @var array
+   */
+  protected static $modules = [
+    'block',
+    'group',
+    'domain',
+    'localgov_microsites_group',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'localgov_base';
+
+  /**
+   * Regular authenticated User for tests.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $otherUser;
+
+  /**
+   * User administrator of group 1.
+   *
+   * @var \Drupal\user\UserInterface
+   */
+  protected $adminUser;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    // Test uses groups on control domain, so disable group sites.
+    $this->ownerUser = $this->createUser(['use group_sites admin mode']);
+    $this->adminUser1 = $this->createUser(['use group_sites admin mode']);
+    $this->adminUser2 = $this->createUser(['use group_sites admin mode']);
+    $this->memberUser1 = $this->createUser(['use group_sites admin mode']);
+    $this->memberUser2 = $this->createUser(['use group_sites admin mode']);
+    $this->otherUser = $this->createUser(['use group_sites admin mode']);
+    $this->createMicrositeGroups([
+      'uid' => $this->ownerUser->id(),
+    ]);
+    $this->groups[1]->addMember($this->adminUser1, ['group_roles' => 'microsite-admin']);
+    $this->groups[2]->addMember($this->adminUser2, ['group_roles' => 'microsite-admin']);
+
+    $this->createMicrositeGroupsDomains($this->groups);
+  }
+
+  /**
+   * Test access to manage content.
+   */
+  public function testGroupAdminAccess() {
+    $group1 = $this->groups[1];
+    $group2 = $this->groups[2];
+
+    // Admin1 can access content on site 1.
+    $group1_domain = $this->getDomainFromGroup($group1 );
+    $group2_domain = $this->getDomainFromGroup($group2);
+    assert($group1_domain instanceof DomainInterface);
+    $this->drupalGet($group1_domain->getUrl() . Url::fromRoute('user.login')->toString());
+    $this->submitForm([
+      'name' => $this->adminUser1->getAccountName(),
+      'pass' => $this->adminUser1->passRaw,
+    ], 'Log in');
+
+    // Confirm that adminUser1 can manage nodes on group2.
+    $this->drupalGet($group1_domain->getUrl() . '/group/' . $group1->id() . '/nodes');
+    $this->assertSession()->statusCodeEquals(200);
+
+    // First login to group2 domain.
+    $this->drupalGet($group2_domain->getUrl() . Url::fromRoute('user.login')->toString());
+    $this->submitForm([
+      'name' => $this->adminUser1->getAccountName(),
+      'pass' => $this->adminUser1->passRaw,
+    ], 'Log in');
+
+    // Now confirm that adminUser1 cannot manage nodes on group2.
+    $this->drupalGet($group2_domain->getUrl() . '/group/' . $group2->id() . '/nodes');
+    $this->assertSession()->statusCodeEquals(403);
+
+  }
+
+}

--- a/tests/src/Functional/GroupInvitationAccessTest.php
+++ b/tests/src/Functional/GroupInvitationAccessTest.php
@@ -73,8 +73,8 @@ class GroupInvitationAccessTest extends BrowserTestBase {
     $this->createMicrositeGroups([
       'uid' => $this->ownerUser->id(),
     ]);
-    $this->groups[0]->addMember($this->adminUser, ['group_roles' => 'microsite-admin']);
-    $this->groups[0]->addMember($this->memberUser);
+    $this->groups[1]->addMember($this->adminUser, ['group_roles' => 'microsite-admin']);
+    $this->groups[1]->addMember($this->memberUser);
     $this->createMicrositeGroupsDomains($this->groups);
   }
 
@@ -82,7 +82,7 @@ class GroupInvitationAccessTest extends BrowserTestBase {
    * Test content access when unique group access is enabled.
    */
   public function testInvitationPermissions() {
-    $group = $this->groups[0];
+    $group = $this->groups[1];
 
     // Admin can check invitations.
     $this->drupalLogin($this->adminUser);

--- a/tests/src/Functional/LoginTest.php
+++ b/tests/src/Functional/LoginTest.php
@@ -84,7 +84,7 @@ class LoginTest extends BrowserTestBase {
     // Can't use drupalLogin as we want to do it on the form with the microsite
     // domain.
     // @todo move this into a trait, probably on domain_group.
-    $ga1_domain = $this->getDomainFromGroup($this->groups[0]);
+    $ga1_domain = $this->getDomainFromGroup($this->groups[1]);
     assert($ga1_domain instanceof DomainInterface);
     $this->drupalGet($ga1_domain->getUrl() . Url::fromRoute('user.login')->toString());
     $this->submitForm([

--- a/tests/src/Functional/MicrositeCachingTest.php
+++ b/tests/src/Functional/MicrositeCachingTest.php
@@ -58,7 +58,7 @@ class MicrositeCachingTest extends BrowserTestBase {
 
     // Create some microsites.
     $this->group = $this->createGroup([
-      'label' => 'group-0',
+      'label' => 'group-1',
       'type' => 'microsite',
     ]);
     $this->domain = \Drupal::entityTypeManager()->getStorage('domain')->create([

--- a/tests/src/Functional/MicrositeSitewideSearchTest.php
+++ b/tests/src/Functional/MicrositeSitewideSearchTest.php
@@ -61,15 +61,15 @@ class MicrositeSitewideSearchTest extends BrowserTestBase {
 
     $this->createMicrositeGroups([], 2);
     $this->createMicrositeGroupsDomains($this->groups);
-    $this->domain1 = $this->getDomainFromGroup($this->groups[0]);
-    $this->domain2 = $this->getDomainFromGroup($this->groups[1]);
+    $this->domain1 = $this->getDomainFromGroup($this->groups[1]);
+    $this->domain2 = $this->getDomainFromGroup($this->groups[2]);
 
     // Create some content.
     $this->pages1 = [
-      $this->createPage($this->groups[0]),
-      $this->createPage($this->groups[0]),
+      $this->createPage($this->groups[1]),
+      $this->createPage($this->groups[1]),
     ];
-    $this->pages2 = [$this->createPage($this->groups[1])];
+    $this->pages2 = [$this->createPage($this->groups[2])];
 
     // Index directory content.
     $index = Index::load('localgov_sitewide_search');

--- a/tests/src/Functional/ModuleSettingsFormTest.php
+++ b/tests/src/Functional/ModuleSettingsFormTest.php
@@ -60,8 +60,8 @@ class ModuleSettingsFormTest extends BrowserTestBase {
     $this->createMicrositeGroups([
       'uid' => $this->ownerUser->id(),
     ]);
-    $this->groups[0]->addMember($this->adminUser, ['group_roles' => 'microsite-admin']);
-    $this->groups[0]->addMember($this->memberUser);
+    $this->groups[1]->addMember($this->adminUser, ['group_roles' => 'microsite-admin']);
+    $this->groups[1]->addMember($this->memberUser);
     $this->createMicrositeGroupsDomains($this->groups);
   }
 
@@ -69,7 +69,7 @@ class ModuleSettingsFormTest extends BrowserTestBase {
    * Test group domain settings form.
    */
   public function testDomainGroupForm() {
-    $group = $this->groups[0];
+    $group = $this->groups[1];
     // Going to domain group settings form.
     $this->drupalLogin($this->adminUser);
     \Drupal::service('group_sites.admin_mode')->setAdminMode(TRUE);
@@ -105,7 +105,7 @@ class ModuleSettingsFormTest extends BrowserTestBase {
    * Test access to group management pages.
    */
   public function testGroupManagementAccess() {
-    $group = $this->groups[0];
+    $group = $this->groups[1];
 
     // Test admin access.
     $this->drupalLogin($this->adminUser);

--- a/tests/src/Traits/InitializeGroupsTrait.php
+++ b/tests/src/Traits/InitializeGroupsTrait.php
@@ -38,7 +38,7 @@ trait InitializeGroupsTrait {
    *   Groups generated also assigned to $this->groups.
    */
   public function createMicrositeGroups(array $settings = [], int $count = 5) {
-    for ($i = 0; $i < $count; $i++) {
+    for ($i = 1; $i <= $count; $i++) {
       $group = Group::create($settings + [
         'type' => 'microsite',
         'label' => $this->randomString(),


### PR DESCRIPTION
@ekes I was getting confused in the tests where the groups[$key] was off by one to the $group->id(), so tweaked them to align.

Is this OK? 

Could you pass your eyes over it and also tell me if the [GroupAdminAccessTest](https://github.com/localgovdrupal/localgov_microsites_group/pull/459/files#diff-70abab5ecd8e0766c300e5fd708d10e6b2fd8d9f00a9f8735261fed472e5680a) is doing what I think it is doing?

Thank you!