### PR TITLE
Fix: Inherited trait property declaration

### DIFF
--- a/src/DomainGroupResolver.php
+++ b/src/DomainGroupResolver.php
@@ -29,20 +29,6 @@ class DomainGroupResolver implements DomainGroupResolverInterface {
   use GroupFromDomainContextTrait;
 
   /**
-   * The entity type manager.
-   *
-   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
-   */
-  protected $entityTypeManager;
-
-  /**
-   * The domain negotiator service.
-   *
-   * @var \Drupal\Domain\DomainNegotiatorInterface
-   */
-  protected $domainNegotiator;
-
-  /**
    * DomainGroupHelper constructor.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
@@ -54,7 +40,7 @@ class DomainGroupResolver implements DomainGroupResolverInterface {
    * @param \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
    *   Current entity repository interface.
    */
-  public function __construct(EntityTypeManagerInterface $entity_type_manager, DomainNegotiatorInterface $domain_negotiator, RouteMatchInterface $current_route_match, EntityRepositoryInterface $entity_repository) {
+  public function __construct(protected EntityTypeManagerInterface $entity_type_manager, protected DomainNegotiatorInterface $domain_negotiator, protected RouteMatchInterface $current_route_match, protected EntityRepositoryInterface $entity_repository) {
     $this->entityTypeManager = $entity_type_manager;
     $this->domainNegotiator = $domain_negotiator;
     $this->currentRouteMatch = $current_route_match;

--- a/src/DomainGroupResolver.php
+++ b/src/DomainGroupResolver.php
@@ -40,7 +40,7 @@ class DomainGroupResolver implements DomainGroupResolverInterface {
    * @param \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
    *   Current entity repository interface.
    */
-  public function __construct(protected EntityTypeManagerInterface $entity_type_manager, protected DomainNegotiatorInterface $domain_negotiator, protected RouteMatchInterface $current_route_match, protected EntityRepositoryInterface $entity_repository) {
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, DomainNegotiatorInterface $domain_negotiator, RouteMatchInterface $current_route_match, EntityRepositoryInterface $entity_repository) {
     $this->entityTypeManager = $entity_type_manager;
     $this->domainNegotiator = $domain_negotiator;
     $this->currentRouteMatch = $current_route_match;


### PR DESCRIPTION
Calls to Drupal::service('domain_group_resolver') are causing WSOD :(  Error message says `PHP Fatal error:  Drupal\localgov_microsites_group\DomainGroupResolver and Drupal\group_context_domain\GroupFromDomainContextTrait define the same property ($domainNegotiator) in the composition of Drupal\localgov_microsites_group\DomainGroupResolver. However, the definition differs and is considered incompatible. Class was composed in /path/to/drupal/web/modules/contrib/localgov_microsites_group/src/DomainGroupResolver.php on line 24`

This is due to [recent changes](https://www.php.net/trait#language.oop5.traits.properties.example) to Drupal\group_context_domain\GroupFromDomainContextTrait