### PR TITLE
Patch group module to support previewing content.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,9 @@
             },
             "drupal/ginvite": {
                 "View schema fix #3324625": "https://www.drupal.org/files/issues/2022-11-30/3324625-2-schema-fix-for-4.0.x.patch"
+            },
+            "drupal/group": {
+                "Patch group to support previewing content.": "https://www.drupal.org/files/issues/2023-09-25/group2-2853001-26.patch"
             }
         }
     }


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Add's a patch : 

https://www.drupal.org/files/issues/2023-09-25/group2-2853001-26.patch

From: 

http://drupal.org/node/2853001

## How to test

For now, I'm just testing this patch to see if it helps with the preview_link and responsive_preview functionality.
