### PR TITLE
Add patch from https://www.drupal.org/project/group/issues/2853001 to…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,9 @@
             },
             "drupal/ginvite": {
                 "View schema fix #3324625": "https://www.drupal.org/files/issues/2022-11-30/3324625-2-schema-fix-for-4.0.x.patch"
+            },
+            "drupal/group": {
+                "Fix Warning: Undefined array key 'preview' in formAlter(). https://www.drupal.org/project/group/issues/2853001": "https://www.drupal.org/files/issues/2023-09-25/group2-2853001-26.patch"
             }
         }
     }


### PR DESCRIPTION
This an issue, again!

Just like mentioned here: https://www.drupal.org/project/responsive_preview/issues/3302861

Which takes us back to https://www.drupal.org/project/group/issues/2853001

The latest patch on there seems to suppress the problem.

Steps to reporoduce:

install localgov_microsites 4.0.0 :)
create a microsite and assign an admin user to the microsite
log into microsite as admin user
create a newsroom
See

Error message

> Warning: Undefined array key "preview" in Drupal\responsive_preview\ResponsivePreview->formAlter() (line 221 of modules/contrib/responsive_preview/src/ResponsivePreview.php).
> 
> Warning: Trying to access array offset on value of type null in Drupal\responsive_preview\ResponsivePreview->formAlter() (line 221 of modules/contrib/responsive_preview/src/ResponsivePreview.php).
> 

Solution: apply this patch https://www.drupal.org/files/issues/2023-09-25/group2-2853001-26.patch

