### PR TITLE
Remove sticky header from content types form table.

### DIFF
--- a/src/Plugin/DomainGroupSettings/ContentTypeSettings.php
+++ b/src/Plugin/DomainGroupSettings/ContentTypeSettings.php
@@ -105,7 +105,7 @@ class ContentTypeSettings extends DomainGroupSettingsBase implements ContainerFa
       ],
       '#id' => 'modules',
       '#attributes' => ['class' => ['modules']],
-      '#sticky' => TRUE,
+      '#sticky' => FALSE,
     ];
     foreach ($module_permissions as $module_name => $status) {
       $module = $this->moduleExtensionList->getExtensionInfo($module_name);


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Removes the sticky header from the Content Types form table when editing a microsite content types. 

## How to test

1. Fresh install of localgov_microsites.
2. Create a microsite.
3. Go to: https://localgov-micro-1.ddev.site/group/1/domain-settings

Before: 

![image](https://github.com/user-attachments/assets/9c2298e6-5749-4160-89b9-033e98555213)

After: 

![image](https://github.com/user-attachments/assets/7089096c-1ec6-4bb4-b655-51678536ca40)
