### PR TITLE
Use RC version of ginvite 4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "require": {
         "drupal/domain_path": "^1.2",
         "drupal/field_formatter_class": "^1.5",
-        "drupal/ginvite": "4.0.0-alpha1",
+        "drupal/ginvite": "^4.0@RC",
         "drupal/group": "^3.2",
         "drupal/group_content_menu": "^3.0",
         "drupal/group_context_domain": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -40,9 +40,6 @@
             "drupal/domain_path": {
                 "domain_path_pathauto creates duplicate aliases #3285213": "https://www.drupal.org/files/issues/2022-06-11/domain_path_pathauto-obey-current-domain_id-querying-for-reserved-aliases-3285213.patch",
                 "Warning: Undefined array key 'pathauto' #3315752": "https://www.drupal.org/files/issues/2022-10-17/undefined-array-key-pathauto-3265497-2.patch"
-            },
-            "drupal/ginvite": {
-                "View schema fix #3324625": "https://www.drupal.org/files/issues/2022-11-30/3324625-2-schema-fix-for-4.0.x.patch"
             }
         }
     }


### PR DESCRIPTION
## What does this change?

Uses RC version of Group Invite and adds composer rule to track latest releases.

## How to test

Group Invite module version RC installs and works with show errors and warnings, such as the one in #504 
