### PR TITLE
Hide front and error page settings from microsite controllers 

### DIFF
--- a/src/Form/DomainGroupSettingsForm.php
+++ b/src/Form/DomainGroupSettingsForm.php
@@ -92,7 +92,7 @@ class DomainGroupSettingsForm extends FormBase {
     ];
 
     // Hide configuration options that site controllers don't have access to.
-    if (in_array('microsites_controller', $this->currentUser->getRoles())) {
+    if (!$group->hasPermission('access group_node overview', $this->currentUser)) {
       $form['domain_group_site_settings']['error_page']['#access'] = FALSE;
       $form['domain_group_site_settings']['site_frontpage']['#access'] = FALSE;
     }

--- a/src/Form/DomainGroupSettingsForm.php
+++ b/src/Form/DomainGroupSettingsForm.php
@@ -16,6 +16,13 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class DomainGroupSettingsForm extends FormBase {
 
   /**
+  * Current user account.
+  *
+  * @var \Drupal\Core\Session\AccountInterface
+  */
+  protected AccountInterface $currentUser;
+
+  /**
    * The DomainGroupSettingsManager service.
    *
    * @var \Drupal\localgov_microsites_group\Plugin\DomainGroupSettingsManager
@@ -25,7 +32,8 @@ class DomainGroupSettingsForm extends FormBase {
   /**
    * Constructs a new DomainGroupSettingsForm object.
    */
-  public function __construct(DomainGroupSettingsManager $plugin_manager_domain_group_settings) {
+  public function __construct(AccountInterface $current_user, DomainGroupSettingsManager $plugin_manager_domain_group_settings) {
+    $this->currentUser = $current_user;
     $this->pluginManagerDomainGroupSettings = $plugin_manager_domain_group_settings;
   }
 
@@ -34,6 +42,7 @@ class DomainGroupSettingsForm extends FormBase {
    */
   public static function create(ContainerInterface $container) {
     return new static(
+      $container->get('current_user'),
       $container->get('plugin.manager.domain_group_settings')
     );
   }
@@ -81,6 +90,12 @@ class DomainGroupSettingsForm extends FormBase {
       '#type' => 'submit',
       '#value' => $this->t('Submit'),
     ];
+
+    // Hide configuration options that site controllers don't have access to.
+    if (in_array('microsites_controller', $this->currentUser->getRoles())) {
+      $form['domain_group_site_settings']['error_page']['#access'] = FALSE;
+      $form['domain_group_site_settings']['site_frontpage']['#access'] = FALSE;
+    }
 
     return $form;
   }

--- a/src/Form/DomainGroupSettingsForm.php
+++ b/src/Form/DomainGroupSettingsForm.php
@@ -93,8 +93,8 @@ class DomainGroupSettingsForm extends FormBase {
 
     // Hide configuration options that site controllers don't have access to.
     if (!$group->hasPermission('access group_node overview', $this->currentUser)) {
-      $form['domain_group_site_settings']['error_page']['#access'] = FALSE;
-      $form['domain_group_site_settings']['site_frontpage']['#access'] = FALSE;
+      unset($form['domain_group_site_settings']['error_page']);
+      unset($form['domain_group_site_settings']['site_frontpage']);
     }
 
     return $form;

--- a/src/Form/DomainGroupSettingsForm.php
+++ b/src/Form/DomainGroupSettingsForm.php
@@ -16,10 +16,10 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class DomainGroupSettingsForm extends FormBase {
 
   /**
-  * Current user account.
-  *
-  * @var \Drupal\Core\Session\AccountInterface
-  */
+   * Current user account.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
   protected AccountInterface $currentUser;
 
   /**

--- a/tests/src/Kernel/SettingsFormAccessTest.php
+++ b/tests/src/Kernel/SettingsFormAccessTest.php
@@ -58,7 +58,7 @@ class SettingsFormAccessTest extends GroupKernelTestBase {
    * Test the access form with anonymous, member and admin.
    */
   public function testFormAccess() {
-    $form = new DomainGroupSettingsForm($this->container->get('plugin.manager.domain_group_settings'));
+    $form = new DomainGroupSettingsForm($this->getCurrentUser(), $this->container->get('plugin.manager.domain_group_settings'));
 
     // Non-member.
     $this->assertFalse($form->access($this->group, $this->getCurrentUser())->isAllowed());


### PR DESCRIPTION
Fixes localgovdrupal/localgov_microsites#486

## What does this change?

Removes the Site front page and error pages fields from the site settings form for a microsite for microsite controllers as they don't have permission to access these.

This checks whether the user has the Microsites Controller role, but I realise it maybe better to check for the relevant group content permissions. Let's discuss.

## How to test

Check the fields are there for site admins but not for controllers.

## Images

### Site admin

![image](https://github.com/user-attachments/assets/6b00b157-bb08-4852-8906-175532f9eb5c)

### Microsite controller

![image](https://github.com/user-attachments/assets/4f3b9cf1-7151-468d-9aa7-aa424587f07e)
