### PR TITLE
fix: test failure

### DIFF
--- a/modules/localgov_microsites_group_term_ui/src/Plugin/EntityReferenceSelection/GroupTermSelection.php
+++ b/modules/localgov_microsites_group_term_ui/src/Plugin/EntityReferenceSelection/GroupTermSelection.php
@@ -44,14 +44,14 @@ class GroupTermSelection extends TermSelection {
    *   The current user.
    * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
    *   The entity field manager.
-   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
-   *   The entity type bundle info service.
    * @param \Drupal\Core\Entity\EntityRepositoryInterface $entity_repository
    *   The entity repository.
    * @param \Drupal\domain\DomainNegotiatorInterface $domainNegotiator
    *   The domain negotiator service.
+   * @param \Drupal\Core\Entity\EntityTypeBundleInfoInterface $entity_type_bundle_info
+   *   The entity type bundle info service.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, ModuleHandlerInterface $module_handler, AccountInterface $current_user, EntityFieldManagerInterface $entity_field_manager, ?EntityTypeBundleInfoInterface $entity_type_bundle_info = NULL, EntityRepositoryInterface $entity_repository, protected DomainNegotiatorInterface $domainNegotiator) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, ModuleHandlerInterface $module_handler, AccountInterface $current_user, EntityFieldManagerInterface $entity_field_manager, EntityRepositoryInterface $entity_repository, protected DomainNegotiatorInterface $domainNegotiator, ?EntityTypeBundleInfoInterface $entity_type_bundle_info = NULL) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager, $module_handler, $current_user, $entity_field_manager, $entity_type_bundle_info, $entity_repository);
   }
 
@@ -67,9 +67,9 @@ class GroupTermSelection extends TermSelection {
       $container->get('module_handler'),
       $container->get('current_user'),
       $container->get('entity_field.manager'),
-      $container->get('entity_type.bundle.info'),
       $container->get('entity.repository'),
-      $container->get('domain.negotiator')
+      $container->get('domain.negotiator'),
+      $container->get('entity_type.bundle.info')
     );
   }
 

--- a/tests/src/Functional/LoginTest.php
+++ b/tests/src/Functional/LoginTest.php
@@ -23,6 +23,11 @@ class LoginTest extends BrowserTestBase {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  protected bool $useOneTimeLoginLinks = FALSE;
+
+  /**
    * Will be removed when issue #3204455 on Domain Site Settings gets merged.
    *
    * See https://www.drupal.org/project/domain_site_settings/issues/3204455.


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Fix #503 test failure due to change introduced in Drupal 10.3.4 (https://www.drupal.org/project/drupal/issues/3469309)

GroupTermSelection change fixes the below test error
```
Deprecated function: Optional parameter $entity_type_bundle_info declared before required parameter $domainNegotiator is implicitly treated as a required parameter
include()() (Line: 576)
```