### PR TITLE
Limit the accessible domain path settings to the active domain 

### DIFF
--- a/localgov_microsites_group.module
+++ b/localgov_microsites_group.module
@@ -9,6 +9,7 @@ use Drupal\Component\Serialization\Yaml;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Cache\RefinableCacheableDependencyInterface;
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
+use Drupal\Core\Entity\EntityFormInterface;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\Element;
@@ -233,16 +234,21 @@ function localgov_microsites_group_form_user_login_form_alter(&$form, FormStateI
  */
 function localgov_microsites_group_form_alter(&$form, FormStateInterface $form_state, $form_id) {
 
-  // Set domain path pathauto as on by default for new nodes.
-  if (
-    $form_state->getFormObject() instanceof EntityFormInterface &&
-    $form_state->getFormObject()->getEntity()->isNew() &&
-    isset($form['domain_path'])
-  ) {
+  if (isset($form['domain_path'])) {
     $domain_ids = Element::children($form['domain_path']);
     $active_domain = \Drupal::service('domain.negotiator')->getActiveDomain();
     foreach ($domain_ids as $id) {
-      if (isset($form['domain_path'][$id]['pathauto']) && $id == $active_domain->id()) {
+
+      // Hide path auto settings for all but the active domain.
+      if ($id !== $active_domain->id()) {
+        $form['domain_path'][$id]['#access'] = FALSE;
+      }
+
+      // Set domain path pathauto as on by default for new nodes.
+      elseif (
+        $form_state->getFormObject() instanceof EntityFormInterface &&
+        $form_state->getFormObject()->getEntity()->isNew()
+      ) {
         $form['domain_path'][$id]['pathauto']['#default_value'] = TRUE;
       }
     }


### PR DESCRIPTION
## What does this change?

Hides the path settings for all the domains apart from the active one.

## How to test

When editing a page on a site you should only be able to see path settings for the site you're on.

When creating a new node the generate automatic URL checkbox should be checked.

Fixes #509