### PR TITLE
Ensure deprecated variationcache module is included and then uninstall it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "drupal/override_node_options": "^2.6",
         "drupal/replicate": "^1.0",
         "drupal/role_delegation": "^1.2",
+        "drupal/variationcache": "^1.5",
         "localgovdrupal/group_webform": "^1.0.0-beta2",
         "localgovdrupal/localgov_core": "^2.12",
         "localgovdrupal/localgov_forms": "^1.0.0-beta2",

--- a/localgov_microsites_group.install
+++ b/localgov_microsites_group.install
@@ -107,3 +107,10 @@ function localgov_microsites_group_update_9009() {
   $group_sites->set('site_access_policy', 'localgov_microsites_group.microsite_content_types_access_policy');
   $group_sites->save();
 }
+
+/**
+ * Uninstall variationcache module.
+ */
+function localgov_microsites_group_update_10001(&$sandbox) {
+  \Drupal::service('module_installer')->uninstall(['variationcache']);
+}


### PR DESCRIPTION
Fixes #513

## What does this change?

The deprecated variationcache module is removed as a dependency from Group. As it's no longer required ensure it exists and uninstall it.

## How to test

Check variationcache module is uninstalled and the site still functions.
