### PR TITLE
[#526] fix: Require Group 3.3.x when removing variationcache.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "drupal/domain_path": "^1.2",
         "drupal/field_formatter_class": "^1.5",
         "drupal/ginvite": "^4.0@RC",
-        "drupal/group": "^3.2",
+        "drupal/group": "^3.3",
         "drupal/group_content_menu": "^3.0",
         "drupal/group_context_domain": "^1.0",
         "drupal/group_sites": "^1.0",


### PR DESCRIPTION
Shouldn't remove variationcache with 3.2.x installed still.

3.2 depends on flexible_permissions 1.x which is still a full module depending on variationcache (even if it's just the 1.5 stub version).
3.3 depends on flexible_permisisons 2.x which is a stub module removing the dependency on variationcache.