### PR TITLE
Add field_domain_access value to domain_path forms

### DIFF
--- a/localgov_microsites_group.module
+++ b/localgov_microsites_group.module
@@ -243,9 +243,25 @@ function localgov_microsites_group_form_alter(&$form, FormStateInterface $form_s
       if ($id !== $active_domain->id()) {
         $form['domain_path'][$id]['#access'] = FALSE;
       }
+      else {
+
+        // The Domain Path module does a lot of checks for domain access
+        // configuration, but we use the Group module for access checks. Adding
+        // the domain access field to the form ensures the Domain Path checks
+        // pass, but is a bit of a hack as it would be better to fix whatever
+        // is going wrong in the Domain Path module.
+        if (!isset($form['field_domain_access'])) {
+          $form['field_domain_access'] = [
+            '#type' => 'value',
+            '#value' => [
+              [ 'target_id' => $id ],
+            ],
+          ];
+        }
+      }
 
       // Set domain path pathauto as on by default for new nodes.
-      elseif (
+      if (
         $form_state->getFormObject() instanceof EntityFormInterface &&
         $form_state->getFormObject()->getEntity()->isNew()
       ) {

--- a/localgov_microsites_group.module
+++ b/localgov_microsites_group.module
@@ -245,7 +245,7 @@ function localgov_microsites_group_form_alter(&$form, FormStateInterface $form_s
         $form['domain_path'][$id]['#access'] = FALSE;
       }
       else {
-        $domain_access[] = [ 'target_id' => $id ];
+        $domain_access[] = ['target_id' => $id];
       }
 
       // Set domain path pathauto as on by default for new nodes.

--- a/localgov_microsites_group.module
+++ b/localgov_microsites_group.module
@@ -237,6 +237,7 @@ function localgov_microsites_group_form_alter(&$form, FormStateInterface $form_s
   if (isset($form['domain_path'])) {
     $domain_ids = Element::children($form['domain_path']);
     $active_domain = \Drupal::service('domain.negotiator')->getActiveDomain();
+    $domain_access = [];
     foreach ($domain_ids as $id) {
 
       // Hide path auto settings for all but the active domain.
@@ -244,20 +245,7 @@ function localgov_microsites_group_form_alter(&$form, FormStateInterface $form_s
         $form['domain_path'][$id]['#access'] = FALSE;
       }
       else {
-
-        // The Domain Path module does a lot of checks for domain access
-        // configuration, but we use the Group module for access checks. Adding
-        // the domain access field to the form ensures the Domain Path checks
-        // pass, but is a bit of a hack as it would be better to fix whatever
-        // is going wrong in the Domain Path module.
-        if (!isset($form['field_domain_access'])) {
-          $form['field_domain_access'] = [
-            '#type' => 'value',
-            '#value' => [
-              [ 'target_id' => $id ],
-            ],
-          ];
-        }
+        $domain_access[] = [ 'target_id' => $id ];
       }
 
       // Set domain path pathauto as on by default for new nodes.
@@ -267,6 +255,18 @@ function localgov_microsites_group_form_alter(&$form, FormStateInterface $form_s
       ) {
         $form['domain_path'][$id]['pathauto']['#default_value'] = TRUE;
       }
+    }
+
+    // The Domain Path module does a lot of checks for domain access
+    // configuration, but we use the Group module for access checks. Adding the
+    // domain access field to the form ensures the Domain Path checks pass, but
+    // is a bit of a hack as it would be better to fix whatever is going wrong
+    // in the Domain Path module.
+    if (!isset($form['field_domain_access'])) {
+      $form['field_domain_access'] = [
+        '#type' => 'value',
+        '#value' => $domain_access,
+      ];
     }
   }
 }


### PR DESCRIPTION
The Domain Path module does a lot of checks for domain access configuration, but we use the Group module for access checks. Adding the domain access field to the form ensures the Domain Path checks pass, but is a bit of a hack as it would be better to fix whatever is going wrong in the Domain Path module.

## What does this change?

Adds a field_domain_access value field to the forms with domain_path field to ensure that logic that does domain access checks pass.

## How to test

Saving paths on microsite nodes should now work.

## Have we considered potential risks?

This is a bit if a hack. It would be better to work out what's going wrong in the Domain Path module and patch it.

This most definitely needs tests. These would be necessary even if we patched the Domain Path module.
