### PR TITLE
chore: drop compatibility layer now 10.3 is minimum support version

### DIFF
--- a/src/Plugin/DomainGroupSettings/MicrositeDomain.php
+++ b/src/Plugin/DomainGroupSettings/MicrositeDomain.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\localgov_microsites_group\Plugin\DomainGroupSettings;
 
-use Drupal\Component\Utility\DeprecationHelper;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;

--- a/src/Plugin/DomainGroupSettings/MicrositeDomain.php
+++ b/src/Plugin/DomainGroupSettings/MicrositeDomain.php
@@ -160,12 +160,7 @@ class MicrositeDomain extends DomainGroupSettingsBase implements ContainerFactor
         ];
         /** @var \Drupal\Core\Render\RendererInterface $renderer */
         $renderer = $this->renderer;
-        $message = DeprecationHelper::backwardsCompatibleCall(
-          currentVersion: \Drupal::VERSION,
-          deprecatedVersion: '10.3',
-          currentCallable: fn() => $renderer->renderInIsolation($message),
-          deprecatedCallable: fn() => $renderer->renderPlain($message),
-        );
+        $message = $renderer->renderInIsolation($message);
         $form_state->setErrorByName('hostname', $message);
       }
     }


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

Some housekeeping now that 10.3 is the minimum supported Drupal core, so we no longer need this backwards compatible layer.