### PR TITLE
Patch: Undefined array key 'pathauto' no longer applies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "drupal-module",
     "license": "GPL-2.0-or-later",
     "require": {
-        "drupal/domain_path": "^1.2",
+        "drupal/domain_path": "^1.5",
         "drupal/field_formatter_class": "^1.5",
         "drupal/ginvite": "^4.0@RC",
         "drupal/group": "^3.3",
@@ -39,8 +39,7 @@
         },
         "patches": {
             "drupal/domain_path": {
-                "domain_path_pathauto creates duplicate aliases #3285213": "https://www.drupal.org/files/issues/2022-06-11/domain_path_pathauto-obey-current-domain_id-querying-for-reserved-aliases-3285213.patch",
-                "Warning: Undefined array key 'pathauto' #3315752": "https://www.drupal.org/files/issues/2022-10-17/undefined-array-key-pathauto-3265497-2.patch"
+                "domain_path_pathauto creates duplicate aliases #3285213": "https://www.drupal.org/files/issues/2022-06-11/domain_path_pathauto-obey-current-domain_id-querying-for-reserved-aliases-3285213.patch"
             }
         }
     }


### PR DESCRIPTION
Removing `domain_path` patch `"Warning: Undefined array key 'pathauto' #3315752": "https://www.drupal.org/files/issues/2022-10-17/undefined-array-key-pathauto-3265497-2.patch"` and bumping `domain_path` version to 1.5
