### PR TITLE
Disable per-domain access control while indexing.

### DIFF
--- a/localgov_microsites_group.services.yml
+++ b/localgov_microsites_group.services.yml
@@ -73,3 +73,9 @@ services:
     tags:
       - { name: 'context_provider' }
     deprecated: 'The "%service_id%" service is deprecated. You should use the group sites context directly instead.'
+
+  localgov_microsites_group.event_subscriber:
+    class: Drupal\localgov_microsites_group\EventSubscriber\SearchApiSubscriber
+    arguments: ['@group_sites.admin_mode']
+    tags:
+      - { name: event_subscriber }

--- a/src/EventSubscriber/SearchApiSubscriber.php
+++ b/src/EventSubscriber/SearchApiSubscriber.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\localgov_microsites_group\EventSubscriber;
+
+use Drupal\group_sites\GroupSitesAdminModeInterface;
+use Drupal\search_api\Event\IndexingItemsEvent;
+use Drupal\search_api\Event\ItemsIndexedEvent;
+use Drupal\search_api\Event\SearchApiEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Switch into Group Sites admin mode when indexing items.
+ *
+ * There is one index. All items go into it so while indexing per-site access
+ * control (including on referenced items) shouldn't kick in.
+ * The results are returned on searches with a group site filter.
+ */
+final class SearchApiSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Constructs a SearchApiSubscriber object.
+   */
+  public function __construct(
+    private readonly GroupSitesAdminModeInterface $groupSitesAdminMode,
+  ) {}
+
+  /**
+   * Preparing items to be indexed.
+   */
+  public function startIndexing(IndexingItemsEvent $event): void {
+    $this->groupSitesAdminMode->setAdminModeOverride(TRUE);
+  }
+
+  /**
+   * Items have been indexed.
+   */
+  public function stopIndexing(ItemsIndexedEvent $event): void {
+    $this->groupSitesAdminMode->setAdminModeOverride(FALSE);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    return [
+      SearchApiEvents::INDEXING_ITEMS => ['startIndexing'],
+      SearchApiEvents::ITEMS_INDEXED => ['stopIndexing'],
+    ];
+  }
+
+}


### PR DESCRIPTION
This populates the index with all items and their referenced items. The items are filtered on output.

See https://github.com/localgovdrupal/localgov_microsites/issues/524

**Requires** https://github.com/localgovdrupal/localgov_directories/pull/442 to work.