### PR TITLE
Adds LocalGov Guides to Microsites

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,10 @@
         "localgovdrupal/localgov_events": "^3.0"
     },
     "suggests": {
-        "localgovdrupal/localgov_directories": "For directories content type in microsites",
-        "localgovdrupal/localgov_news": "For news content type in microsites",
-        "localgovdrupal/localgov_events": "For events content type in microsites"
+        "localgovdrupal/localgov_directories": "For directories content types in microsites",
+        "localgovdrupal/localgov_events": "For events content type in microsites",
+        "localgovdrupal/localgov_guides": "For guides content types in microsites",
+        "localgovdrupal/localgov_news": "For news content types in microsites"
     },
     "extra": {
         "enable-patching": true,

--- a/modules/localgov_microsites_guides/config/install/block.block.localgov_microsites_base_guidecontents.yml
+++ b/modules/localgov_microsites_guides/config/install/block.block.localgov_microsites_base_guidecontents.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - localgov_guides
+    - node
+  theme:
+    - localgov_microsites_base
+id: localgov_microsites_base_guidecontents
+theme: localgov_microsites_base
+region: content_top
+weight: 0
+provider: null
+plugin: localgov_guides_contents
+settings:
+  id: localgov_guides_contents
+  label: 'Guide contents'
+  label_display: '0'
+  provider: localgov_guides
+visibility:
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'
+    bundles:
+      localgov_guides_overview: localgov_guides_overview
+      localgov_guides_page: localgov_guides_page

--- a/modules/localgov_microsites_guides/config/install/block.block.localgov_microsites_base_guidesprevnextblock.yml
+++ b/modules/localgov_microsites_guides/config/install/block.block.localgov_microsites_base_guidesprevnextblock.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - localgov_guides
+    - node
+  theme:
+    - localgov_microsites_base
+id: localgov_microsites_base_guidesprevnextblock
+theme: localgov_microsites_base
+region: content_bottom
+weight: 0
+provider: null
+plugin: localgov_guides_prev_next_block
+settings:
+  id: localgov_guides_prev_next_block
+  label: ''
+  label_display: visible
+  provider: localgov_guides
+  show_title: false
+visibility:
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'
+    bundles:
+      localgov_guides_overview: localgov_guides_overview
+      localgov_guides_page: localgov_guides_page

--- a/modules/localgov_microsites_guides/config/install/group.relationship_type.microsite-b721d90ab46f59c09ae109.yml
+++ b/modules/localgov_microsites_guides/config/install/group.relationship_type.microsite-b721d90ab46f59c09ae109.yml
@@ -1,0 +1,17 @@
+uuid: b4b0a26d-b4c5-457d-8b6e-f20354ae19b2
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.microsite
+    - node.type.localgov_guides_overview
+  module:
+    - gnode
+    - node
+id: microsite-b721d90ab46f59c09ae109
+group_type: microsite
+content_plugin: 'group_node:localgov_guides_overview'
+plugin_config:
+  group_cardinality: 0
+  entity_cardinality: 1
+  use_creation_wizard: false

--- a/modules/localgov_microsites_guides/config/install/group.relationship_type.microsite-e76432b615659e0f60803f.yml
+++ b/modules/localgov_microsites_guides/config/install/group.relationship_type.microsite-e76432b615659e0f60803f.yml
@@ -1,0 +1,16 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.microsite
+    - node.type.localgov_guides_page
+  module:
+    - gnode
+    - node
+id: microsite-e76432b615659e0f60803f
+group_type: microsite
+content_plugin: 'group_node:localgov_guides_page'
+plugin_config:
+  group_cardinality: 0
+  entity_cardinality: 1
+  use_creation_wizard: false

--- a/modules/localgov_microsites_guides/localgov_microsites_guides.info.yml
+++ b/modules/localgov_microsites_guides/localgov_microsites_guides.info.yml
@@ -1,0 +1,9 @@
+name: Localgov Microsites Guides
+description: LocalGov Guides integration with Microsites.
+type: module
+package: LocalGov Drupal
+core_version_requirement: ^10 || ^11
+dependencies:
+  - group:gnode
+  - localgov_guides:localgov_guides
+  - localgov_microsites_group:localgov_microsites_group

--- a/modules/localgov_microsites_guides/localgov_microsites_guides.module
+++ b/modules/localgov_microsites_guides/localgov_microsites_guides.module
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * @file
+ * LocalGov Microsites Guides module file.
+ */
+
+use Drupal\localgov_microsites_group\RolesHelper;
+
+/**
+ * Implements hook_localgov_microsites_roles_default().
+ */
+function localgov_microsites_guides_localgov_microsites_roles_default() {
+  return [
+    'group' => [
+      RolesHelper::GROUP_ADMIN_ROLE => [
+        'access group_term overview',
+        'create group_node:localgov_guides_page entity',
+        'create group_node:localgov_guides_overview entity',
+        'create group_term:localgov_topic entity',
+        'delete any group_node:localgov_guides_page relationship',
+        'delete any group_node:localgov_guides_page entity',
+        'delete any group_node:localgov_guides_overview relationship',
+        'delete any group_node:localgov_guides_overview entity',
+        'delete any group_term:localgov_topic relationship',
+        'delete any group_term:localgov_topic entity',
+        'delete own group_node:localgov_guides_page relationship',
+        'delete own group_node:localgov_guides_page entity',
+        'delete own group_node:localgov_guides_overview relationship',
+        'delete own group_node:localgov_guides_overview entity',
+        'delete own group_term:localgov_topic relationship',
+        'update any group_node:localgov_guides_page relationship',
+        'update any group_node:localgov_guides_page entity',
+        'update any group_node:localgov_guides_overview relationship',
+        'update any group_node:localgov_guides_overview entity',
+        'update any group_term:localgov_topic relationship',
+        'update any group_term:localgov_topic entity',
+        'update own group_node:localgov_guides_page relationship',
+        'update own group_node:localgov_guides_page entity',
+        'update own group_node:localgov_guides_overview relationship',
+        'update own group_node:localgov_guides_overview entity',
+        'update own group_term:localgov_topic relationship',
+        'view any unpublished group_term:localgov_topic entity',
+        'view group_node:localgov_guides_page relationship',
+        'view group_node:localgov_guides_page entity',
+        'view group_node:localgov_guides_overview relationship',
+        'view group_node:localgov_guides_overview entity',
+        'view group_term:localgov_topic relationship',
+        'view group_term:localgov_topic entity',
+        'view unpublished group_node:localgov_guides_page entity',
+        'view unpublished group_node:localgov_guides_overview entity',
+      ],
+      RolesHelper::GROUP_ANONYMOUS_ROLE => [
+        'view group_node:localgov_guides_page entity',
+        'view group_node:localgov_guides_overview entity',
+        'view group_term:localgov_topic entity',
+      ],
+      RolesHelper::GROUP_MEMBER_ROLE => [
+        'access group_term overview',
+        'create group_node:localgov_guides_page entity',
+        'create group_node:localgov_guides_overview entity',
+        'create group_term:localgov_topic entity',
+        'delete any group_term:localgov_topic entity',
+        'update any group_node:localgov_guides_page relationship',
+        'update any group_node:localgov_guides_page entity',
+        'update any group_node:localgov_guides_overview relationship',
+        'update any group_node:localgov_guides_overview entity',
+        'update any group_term:localgov_topic entity',
+        'update own group_node:localgov_guides_page relationship',
+        'update own group_node:localgov_guides_page entity',
+        'update own group_node:localgov_guides_overview relationship',
+        'update own group_node:localgov_guides_overview entity',
+        'view any unpublished group_term:localgov_topic entity',
+        'view group_node:localgov_guides_page entity',
+        'view group_node:localgov_guides_overview entity',
+        'view group_term:localgov_topic entity',
+        'view unpublished group_node:localgov_guides_page entity',
+        'view unpublished group_node:localgov_guides_overview entity',
+        'delete any group_node:localgov_guides_page relationship',
+        'delete any group_node:localgov_guides_page entity',
+        'delete any group_node:localgov_guides_overview relationship',
+        'delete any group_node:localgov_guides_overview entity',
+        'delete own group_node:localgov_guides_page relationship',
+        'delete own group_node:localgov_guides_page entity',
+        'delete own group_node:localgov_guides_overview relationship',
+        'delete own group_node:localgov_guides_overview entity',
+      ],
+      RolesHelper::GROUP_OUTSIDER_ROLE => [
+        'view group_node:localgov_guides_page entity',
+        'view group_node:localgov_guides_overview entity',
+        'view group_term:localgov_topic entity',
+      ],
+    ],
+  ];
+}


### PR DESCRIPTION
Closes #551

## What does this change?

Configures guides module for microsites.

## How to test

- Install the new localgov_microsites_group submodule
- Create a microsites
- See that you can add guide overview and guide pages to the microsite

## How can we measure success?

People no longer ask us to add Guides to Microsites.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.