### PR TITLE
Adds Step-by-Step to Microsites

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,9 @@
     },
     "suggests": {
         "localgovdrupal/localgov_directories": "For directories content type in microsites",
+        "localgovdrupal/localgov_events": "For events content type in microsites",
         "localgovdrupal/localgov_news": "For news content type in microsites",
-        "localgovdrupal/localgov_events": "For events content type in microsites"
+        "localgovdrupal/localgov_step_by_step": "For step by step content types in microsites"
     },
     "extra": {
         "enable-patching": true,

--- a/modules/localgov_microsites_step_by_step/config/install/block.block.localgov_microsites_part_of_step_heading.yml
+++ b/modules/localgov_microsites_step_by_step/config/install/block.block.localgov_microsites_part_of_step_heading.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - localgov_step_by_step
+    - node
+  theme:
+    - localgov_microsites_base
+id: localgov_microsites_part_of_step_heading
+theme: localgov_microsites_base
+region: content
+weight: -11
+provider: null
+plugin: step_part_of_block
+settings:
+  id: step_part_of_block
+  label: 'Part of step heading'
+  label_display: '0'
+  provider: localgov_step_by_step
+visibility:
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'
+    bundles:
+      localgov_step_by_step_overview: localgov_step_by_step_overview
+      localgov_step_by_step_page: localgov_step_by_step_page

--- a/modules/localgov_microsites_step_by_step/config/install/block.block.views_block__localgov_step_by_step_navigation_prev_next.yml
+++ b/modules/localgov_microsites_step_by_step/config/install/block.block.views_block__localgov_step_by_step_navigation_prev_next.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.localgov_step_by_step_navigation
+  module:
+    - node
+    - views
+  theme:
+    - localgov_microsites_base
+id: views_block__localgov_step_by_step_navigation_prev_next
+theme: localgov_microsites_base
+region: content_bottom
+weight: 0
+provider: null
+plugin: 'views_block:localgov_step_by_step_navigation-prev_next'
+settings:
+  id: 'views_block:localgov_step_by_step_navigation-prev_next'
+  label: ''
+  label_display: '0'
+  provider: views
+  context_mapping: {  }
+  views_label: ''
+  items_per_page: none
+visibility:
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'
+    bundles:
+      localgov_step_by_step_overview: localgov_step_by_step_overview
+      localgov_step_by_step_page: localgov_step_by_step_page

--- a/modules/localgov_microsites_step_by_step/config/install/block.block.views_block__localgov_step_by_step_navigation_steps.yml
+++ b/modules/localgov_microsites_step_by_step/config/install/block.block.views_block__localgov_step_by_step_navigation_steps.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.localgov_step_by_step_navigation
+  module:
+    - node
+    - views
+  theme:
+    - localgov_microsites_base
+id: views_block__localgov_step_by_step_navigation_steps
+theme: localgov_microsites_base
+region: sidebar_second
+weight: 0
+provider: null
+plugin: 'views_block:localgov_step_by_step_navigation-steps'
+settings:
+  id: 'views_block:localgov_step_by_step_navigation-steps'
+  label: ''
+  label_display: '0'
+  provider: views
+  context_mapping: {  }
+  views_label: ''
+  items_per_page: none
+visibility:
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'
+    bundles:
+      localgov_step_by_step_overview: localgov_step_by_step_overview
+      localgov_step_by_step_page: localgov_step_by_step_page

--- a/modules/localgov_microsites_step_by_step/config/install/block.block.views_block__localgov_step_by_step_navigation_steps_for_overview.yml
+++ b/modules/localgov_microsites_step_by_step/config/install/block.block.views_block__localgov_step_by_step_navigation_steps_for_overview.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.localgov_step_by_step_navigation
+  module:
+    - node
+    - views
+  theme:
+    - localgov_microsites_base
+id: views_block__localgov_step_by_step_navigation_steps_for_overview
+theme: localgov_microsites_base
+region: content_bottom
+weight: 0
+provider: null
+plugin: 'views_block:localgov_step_by_step_navigation-steps_for_overview'
+settings:
+  id: 'views_block:localgov_step_by_step_navigation-steps_for_overview'
+  label: ''
+  label_display: '0'
+  provider: views
+  context_mapping: {  }
+  views_label: ''
+  items_per_page: none
+visibility:
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'
+    bundles:
+      localgov_step_by_step_overview: localgov_step_by_step_overview
+      localgov_step_by_step_page: localgov_step_by_step_page

--- a/modules/localgov_microsites_step_by_step/config/install/group.relationship_type.microsite-119d08f7d7a7cb5858e490.yml
+++ b/modules/localgov_microsites_step_by_step/config/install/group.relationship_type.microsite-119d08f7d7a7cb5858e490.yml
@@ -1,0 +1,16 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.microsite
+    - node.type.localgov_step_by_step_page
+  module:
+    - gnode
+    - node
+id: microsite-119d08f7d7a7cb5858e490
+group_type: microsite
+content_plugin: 'group_node:localgov_step_by_step_page'
+plugin_config:
+  group_cardinality: 0
+  entity_cardinality: 1
+  use_creation_wizard: false

--- a/modules/localgov_microsites_step_by_step/config/install/group.relationship_type.microsite-7ef30bfab8f4cd75668459.yml
+++ b/modules/localgov_microsites_step_by_step/config/install/group.relationship_type.microsite-7ef30bfab8f4cd75668459.yml
@@ -1,0 +1,16 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - group.type.microsite
+    - node.type.localgov_step_by_step_overview
+  module:
+    - gnode
+    - node
+id: microsite-7ef30bfab8f4cd75668459
+group_type: microsite
+content_plugin: 'group_node:localgov_step_by_step_overview'
+plugin_config:
+  group_cardinality: 0
+  entity_cardinality: 1
+  use_creation_wizard: false

--- a/modules/localgov_microsites_step_by_step/localgov_microsites_step_by_step.info.yml
+++ b/modules/localgov_microsites_step_by_step/localgov_microsites_step_by_step.info.yml
@@ -1,0 +1,9 @@
+name: Localgov Microsites Step-by-Step
+description: LocalGov Step-by-Step integration with Microsites.
+type: module
+package: LocalGov Drupal
+core_version_requirement: ^10 || ^11
+dependencies:
+  - group:gnode
+  - localgov_step_by_step:localgov_step_by_step
+  - localgov_microsites_group:localgov_microsites_group

--- a/modules/localgov_microsites_step_by_step/localgov_microsites_step_by_step.module
+++ b/modules/localgov_microsites_step_by_step/localgov_microsites_step_by_step.module
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * @file
+ * LocalGov Microsites Step-by-Step module file.
+ */
+
+use Drupal\localgov_microsites_group\RolesHelper;
+
+/**
+ * Implements hook_localgov_microsites_roles_default().
+ */
+function localgov_microsites_step_by_step_localgov_microsites_roles_default() {
+  return [
+    'group' => [
+      RolesHelper::GROUP_ADMIN_ROLE => [
+        'access group_term overview',
+        'create group_node:localgov_step_by_step_page entity',
+        'create group_node:localgov_step_by_step_overview entity',
+        'create group_term:localgov_topic entity',
+        'delete any group_node:localgov_step_by_step_page relationship',
+        'delete any group_node:localgov_step_by_step_page entity',
+        'delete any group_node:localgov_step_by_step_overview relationship',
+        'delete any group_node:localgov_step_by_step_overview entity',
+        'delete any group_term:localgov_topic relationship',
+        'delete any group_term:localgov_topic entity',
+        'delete own group_node:localgov_step_by_step_page relationship',
+        'delete own group_node:localgov_step_by_step_page entity',
+        'delete own group_node:localgov_step_by_step_overview relationship',
+        'delete own group_node:localgov_step_by_step_overview entity',
+        'delete own group_term:localgov_topic relationship',
+        'update any group_node:localgov_step_by_step_page relationship',
+        'update any group_node:localgov_step_by_step_page entity',
+        'update any group_node:localgov_step_by_step_overview relationship',
+        'update any group_node:localgov_step_by_step_overview entity',
+        'update any group_term:localgov_topic relationship',
+        'update any group_term:localgov_topic entity',
+        'update own group_node:localgov_step_by_step_page relationship',
+        'update own group_node:localgov_step_by_step_page entity',
+        'update own group_node:localgov_step_by_step_overview relationship',
+        'update own group_node:localgov_step_by_step_overview entity',
+        'update own group_term:localgov_topic relationship',
+        'view any unpublished group_term:localgov_topic entity',
+        'view group_node:localgov_step_by_step_page relationship',
+        'view group_node:localgov_step_by_step_page entity',
+        'view group_node:localgov_step_by_step_overview relationship',
+        'view group_node:localgov_step_by_step_overview entity',
+        'view group_term:localgov_topic relationship',
+        'view group_term:localgov_topic entity',
+        'view unpublished group_node:localgov_step_by_step_page entity',
+        'view unpublished group_node:localgov_step_by_step_overview entity',
+      ],
+      RolesHelper::GROUP_ANONYMOUS_ROLE => [
+        'view group_node:localgov_step_by_step_page entity',
+        'view group_node:localgov_step_by_step_overview entity',
+        'view group_term:localgov_topic entity',
+      ],
+      RolesHelper::GROUP_MEMBER_ROLE => [
+        'access group_term overview',
+        'create group_node:localgov_step_by_step_page entity',
+        'create group_node:localgov_step_by_step_overview entity',
+        'create group_term:localgov_topic entity',
+        'delete any group_term:localgov_topic entity',
+        'update any group_node:localgov_step_by_step_page relationship',
+        'update any group_node:localgov_step_by_step_page entity',
+        'update any group_node:localgov_step_by_step_overview relationship',
+        'update any group_node:localgov_step_by_step_overview entity',
+        'update any group_term:localgov_topic entity',
+        'update own group_node:localgov_step_by_step_page relationship',
+        'update own group_node:localgov_step_by_step_page entity',
+        'update own group_node:localgov_step_by_step_overview relationship',
+        'update own group_node:localgov_step_by_step_overview entity',
+        'view any unpublished group_term:localgov_topic entity',
+        'view group_node:localgov_step_by_step_page entity',
+        'view group_node:localgov_step_by_step_overview entity',
+        'view group_term:localgov_topic entity',
+        'view unpublished group_node:localgov_step_by_step_page entity',
+        'view unpublished group_node:localgov_step_by_step_overview entity',
+        'delete any group_node:localgov_step_by_step_page relationship',
+        'delete any group_node:localgov_step_by_step_page entity',
+        'delete any group_node:localgov_step_by_step_overview relationship',
+        'delete any group_node:localgov_step_by_step_overview entity',
+        'delete own group_node:localgov_step_by_step_page relationship',
+        'delete own group_node:localgov_step_by_step_page entity',
+        'delete own group_node:localgov_step_by_step_overview relationship',
+        'delete own group_node:localgov_step_by_step_overview entity',
+      ],
+      RolesHelper::GROUP_OUTSIDER_ROLE => [
+        'view group_node:localgov_step_by_step_page entity',
+        'view group_node:localgov_step_by_step_overview entity',
+        'view group_term:localgov_topic entity',
+      ],
+    ],
+  ];
+}


### PR DESCRIPTION
Closes #553 

## What does this change?

Configures step-by-step module for microsites.

## How to test

- Install the new localgov_microsites_group submodule
- Create a microsite
- See that you can add step-by-step overview and step-by-step pages to the microsite

## How can we measure success?

People no longer ask us to add Step-by-Steps to Microsites.

---
Thanks to [Big Blue Door](https://www.bigbluedoor.net/) for sponsoring my time to work on this.