### PR TITLE
Fix: Missing update hook for lgms_modules_disabled field on existing installs

### DIFF
--- a/localgov_microsites_group.install
+++ b/localgov_microsites_group.install
@@ -114,3 +114,34 @@ function localgov_microsites_group_update_9009() {
 function localgov_microsites_group_update_10001(&$sandbox) {
   \Drupal::service('module_installer')->uninstall(['variationcache']);
 }
+
+/**
+ * Ensure 'lgms_modules_disabled' field is installed on microsite groups.
+ */
+function localgov_microsites_group_update_10002() {
+  $entity_type_manager = \Drupal::entityTypeManager();
+  $storage_config = $entity_type_manager->getStorage('field_storage_config');
+  $field_config = $entity_type_manager->getStorage('field_config');
+
+  // Ensure field storage exists.
+  if (!$storage_config->load('group.lgms_modules_disabled')) {
+    $storage_config->create([
+      'field_name' => 'lgms_modules_disabled',
+      'entity_type' => 'group',
+      'type' => 'string',
+      'cardinality' => -1,
+      'settings' => ['max_length' => 64],
+    ])->save();
+  }
+
+  // Ensure field instance exists for the microsite bundle.
+  if (!$field_config->load('group.microsite.lgms_modules_disabled')) {
+    $field_config->create([
+      'field_name' => 'lgms_modules_disabled',
+      'entity_type' => 'group',
+      'bundle' => 'microsite',
+      'label' => 'Disabled modules',
+    ])->save();
+  }
+}
+


### PR DESCRIPTION
Description

The field lgms_modules_disabled was introduced to the localgov_microsites_group module (found in config/install), but there is no corresponding update hook to create this field for sites that were installed prior to its introduction.

Currently, code in `ContentTypeHelper::moduleEnable()` assumes this field exists. On older installations, this leads to fatal errors or warnings because the Entity API cannot find the field definition in the active configuration, even if the column has been manually added to the database.

Proposed Resolution
Add an update hook (10002) to `localgov_microsites_group.install` that:

Checks if field.storage.group.lgms_modules_disabled exists.

Checks if field.field.group.microsite.lgms_modules_disabled exists.

Creates them programmatically if they are missing to bring the site schema in line with the module's config/install definitions.