### PR TITLE
Added update hook to front pages to internal node path

### DIFF
--- a/localgov_microsites_group.install
+++ b/localgov_microsites_group.install
@@ -114,3 +114,29 @@ function localgov_microsites_group_update_9009() {
 function localgov_microsites_group_update_10001(&$sandbox) {
   \Drupal::service('module_installer')->uninstall(['variationcache']);
 }
+
+/**
+ * Set microsite front pages to internal node path to prevent alias redirects.
+ */
+function localgov_microsites_group_update_10002() {
+  $config_factory = \Drupal::configFactory();
+  $alias_manager = \Drupal::service('path_alias.manager');
+
+  foreach ($config_factory->listAll('domain.config.') as $config_name) {
+    if (!str_ends_with($config_name, '.system.site')) {
+      continue;
+    }
+
+    $config = $config_factory->getEditable($config_name);
+    $front = $config->get('page.front');
+
+    if (empty($front) || str_starts_with($front, '/node/')) {
+      continue;
+    }
+
+    $internal = $alias_manager->getPathByAlias($front);
+    if (str_starts_with($internal, '/node/')) {
+      $config->set('page.front', $internal)->save();
+    }
+  }
+}


### PR DESCRIPTION
<!-- See https://docs.localgovdrupal.org/contributing/ for guidelines on contributing. -->

## What does this change?

<!-- A pull request should have enough detail to be understandable far in the
future. e.g what is the problem/why is the change needed, how does it solve it
and any questions or points of discussion. Prefer copying information from a
Trello card (for example) over linking to it; the card may not always exist and
reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the
form of "On main, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be
simplified? What can be used to prove this? A filtered view of logs or
analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error
require an alarm? Should user help, infosec, or legal be informed of this
change? Is private information guarded? Do we need to add anything in the
backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and
what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)